### PR TITLE
Refactor terraform trees unit tests

### DIFF
--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/AttributeAccessTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/AttributeAccessTreeImplTest.java
@@ -20,9 +20,9 @@
 package org.sonar.iac.terraform.tree.impl;
 
 import org.junit.jupiter.api.Test;
-import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.AttributeAccessTree;
 import org.sonar.iac.terraform.api.tree.SyntaxToken;
+import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.VariableExprTree;
 import org.sonar.iac.terraform.parser.HclLexicalGrammar;
 
@@ -33,44 +33,36 @@ class AttributeAccessTreeImplTest extends TerraformTreeModelTest {
   @Test
   void simple_attribute_access() {
     AttributeAccessTree tree = parse("a.b", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(a -> {
-      assertThat(a.getKind()).isEqualTo(TerraformTree.Kind.ATTRIBUTE_ACCESS);
-      assertThat(a.attribute().value()).isEqualTo("b");
-      assertThat(a.accessToken()).isInstanceOfSatisfying(SyntaxToken.class, s -> assertThat(s.value()).isEqualTo("."));
-      assertThat(a.object()).isInstanceOfSatisfying(VariableExprTreeImpl.class, o -> assertThat(o.name()).isEqualTo("a"));
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.ATTRIBUTE_ACCESS);
+    assertThat(tree.attribute().value()).isEqualTo("b");
+    assertThat(tree.accessToken()).isInstanceOfSatisfying(SyntaxToken.class, s -> assertThat(s.value()).isEqualTo("."));
+    assertThat(tree.object()).isInstanceOfSatisfying(VariableExprTreeImpl.class, o -> assertThat(o.name()).isEqualTo("a"));
   }
 
   @Test
   void double_attribute_access() {
     AttributeAccessTreeImpl tree = parse("a.b.c", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(a -> {
-      assertThat(a.attribute().value()).isEqualTo("c");
-      assertThat(a.object()).isInstanceOfSatisfying(AttributeAccessTreeImpl.class, o -> {
-        assertThat(o.attribute().value()).isEqualTo("b");
-        assertThat(o.object()).isInstanceOfSatisfying(VariableExprTreeImpl.class, ob -> assertThat(ob.name()).isEqualTo("a"));
-      });
+    assertThat(tree.attribute().value()).isEqualTo("c");
+    assertThat(tree.object()).isInstanceOfSatisfying(AttributeAccessTreeImpl.class, o -> {
+      assertThat(o.attribute().value()).isEqualTo("b");
+      assertThat(o.object()).isInstanceOfSatisfying(VariableExprTreeImpl.class, ob -> assertThat(ob.name()).isEqualTo("a"));
     });
   }
 
   @Test
   void index_access_object() {
     AttributeAccessTree tree = parse("a[1].c", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(a -> {
-      assertThat(a.attribute().value()).isEqualTo("c");
-      assertThat(a.object()).isInstanceOfSatisfying(IndexAccessExprTreeImpl.class, o -> {
-        assertThat(o.subject()).isInstanceOfSatisfying(VariableExprTreeImpl.class, ob -> assertThat(ob.name()).isEqualTo("a"));
-        assertThat(o.index()).isInstanceOfSatisfying(LiteralExprTreeImpl.class, ob -> assertThat(ob.value()).isEqualTo("1"));
-      });
+    assertThat(tree.attribute().value()).isEqualTo("c");
+    assertThat(tree.object()).isInstanceOfSatisfying(IndexAccessExprTreeImpl.class, o -> {
+      assertThat(o.subject()).isInstanceOfSatisfying(VariableExprTreeImpl.class, ob -> assertThat(ob.name()).isEqualTo("a"));
+      assertThat(o.index()).isInstanceOfSatisfying(LiteralExprTreeImpl.class, ob -> assertThat(ob.value()).isEqualTo("1"));
     });
   }
 
   @Test
   void legacy_index_access() {
     AttributeAccessTree tree = parse("a.0", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(a -> {
-      assertThat(a.attribute().value()).isEqualTo("0");
-      assertThat(a.object()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("a"));
-    });
+    assertThat(tree.attribute().value()).isEqualTo("0");
+    assertThat(tree.object()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("a"));
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/AttributeSplatAccessTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/AttributeSplatAccessTreeImplTest.java
@@ -31,10 +31,8 @@ class AttributeSplatAccessTreeImplTest extends TerraformTreeModelTest {
   @Test
   void simple_attribute_splat_access() {
     AttributeSplatAccessTree tree = parse("a.*", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(a -> {
-      assertThat(a.getKind()).isEqualTo(TerraformTree.Kind.ATTRIBUTE_SPLAT_ACCESS);
-      assertThat(a.children()).hasSize(3);
-      assertThat(a.object()).isInstanceOfSatisfying(VariableExprTreeImpl.class, o -> assertThat(o.name()).isEqualTo("a"));
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.ATTRIBUTE_SPLAT_ACCESS);
+    assertThat(tree.children()).hasSize(3);
+    assertThat(tree.object()).isInstanceOfSatisfying(VariableExprTreeImpl.class, o -> assertThat(o.name()).isEqualTo("a"));
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/AttributeTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/AttributeTreeImplTest.java
@@ -20,24 +20,21 @@
 package org.sonar.iac.terraform.tree.impl;
 
 import org.junit.jupiter.api.Test;
+import org.sonar.iac.terraform.api.tree.AttributeTree;
 import org.sonar.iac.terraform.api.tree.LiteralExprTree;
 import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.parser.HclLexicalGrammar;
-import org.sonar.iac.terraform.api.tree.AttributeTree;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AttributeTreeImplTest extends TerraformTreeModelTest{
+
   @Test
   void simple_attribute() {
     AttributeTree tree = parse("a = true", HclLexicalGrammar.ATTRIBUTE);
-    assertThat(tree).isInstanceOfSatisfying(AttributeTree.class, o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.ATTRIBUTE);
-      assertThat(o.name().value()).isEqualTo("a");
-      assertThat(o.equalSign().value()).isEqualTo("=");
-      assertThat(o.value()).isInstanceOfSatisfying(LiteralExprTree.class, a -> {
-        assertThat(a.value()).isEqualTo("true");
-      });
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.ATTRIBUTE);
+    assertThat(tree.name().value()).isEqualTo("a");
+    assertThat(tree.equalSign().value()).isEqualTo("=");
+    assertThat(tree.value()).isInstanceOfSatisfying(LiteralExprTree.class, a -> assertThat(a.value()).isEqualTo("true"));
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/BinaryExpressionTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/BinaryExpressionTreeImplTest.java
@@ -20,11 +20,11 @@
 package org.sonar.iac.terraform.tree.impl;
 
 import org.junit.jupiter.api.Test;
+import org.sonar.iac.terraform.api.tree.BinaryExpressionTree;
 import org.sonar.iac.terraform.api.tree.SyntaxToken;
 import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.VariableExprTree;
 import org.sonar.iac.terraform.parser.HclLexicalGrammar;
-import org.sonar.iac.terraform.api.tree.BinaryExpressionTree;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,12 +33,10 @@ class BinaryExpressionTreeImplTest extends TerraformTreeModelTest {
   @Test
   void simple_binary_expression() {
     BinaryExpressionTree tree = parse("a + b", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.BINARY_EXPRESSION);
-      assertThat(o.children()).hasSize(3);
-      assertThat(o.leftOperand()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("a"));
-      assertThat(o.rightOperand()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("b"));
-      assertThat(o.operator()).isInstanceOfSatisfying(SyntaxToken.class, v -> assertThat(v.value()).isEqualTo("+"));
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.BINARY_EXPRESSION);
+    assertThat(tree.children()).hasSize(3);
+    assertThat(tree.leftOperand()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("a"));
+    assertThat(tree.rightOperand()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("b"));
+    assertThat(tree.operator()).isInstanceOfSatisfying(SyntaxToken.class, v -> assertThat(v.value()).isEqualTo("+"));
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/BlockTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/BlockTreeImplTest.java
@@ -20,9 +20,9 @@
 package org.sonar.iac.terraform.tree.impl;
 
 import org.junit.jupiter.api.Test;
+import org.sonar.iac.terraform.api.tree.BlockTree;
 import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.parser.HclLexicalGrammar;
-import org.sonar.iac.terraform.api.tree.BlockTree;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,11 +31,9 @@ class BlockTreeImplTest extends TerraformTreeModelTest {
   @Test
   void simple_one_line_block() {
     BlockTree tree = parse("a{\n b = true \nc = null}", HclLexicalGrammar.BLOCK);
-    assertThat(tree).isInstanceOfSatisfying(BlockTree.class, o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.BLOCK);
-      assertThat(o.type().value()).isEqualTo("a");
-      assertThat(o.labels()).isEmpty();
-      assertThat(o.body().get().statements()).hasSize(2);
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.BLOCK);
+    assertThat(tree.type().value()).isEqualTo("a");
+    assertThat(tree.labels()).isEmpty();
+    assertThat(tree.body().get().statements()).hasSize(2);
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/BodyTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/BodyTreeImplTest.java
@@ -32,7 +32,6 @@ class BodyTreeImplTest extends TerraformTreeModelTest {
   @Test
   void simple_body_with_one_line_block() {
     BodyTree tree = parse("a {}", HclLexicalGrammar.BODY);
-    assertThat(tree).isInstanceOfSatisfying(BodyTreeImpl.class,  o ->
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.BODY));
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.BODY);
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/ConditionTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/ConditionTreeImplTest.java
@@ -21,8 +21,8 @@ package org.sonar.iac.terraform.tree.impl;
 
 import org.junit.jupiter.api.Test;
 import org.sonar.iac.terraform.api.tree.ConditionTree;
-import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.ExpressionTree;
+import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.VariableExprTree;
 import org.sonar.iac.terraform.parser.HclLexicalGrammar;
 

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/FileTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/FileTreeImplTest.java
@@ -19,10 +19,9 @@
  */
 package org.sonar.iac.terraform.tree.impl;
 
-
 import org.junit.jupiter.api.Test;
-import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.FileTree;
+import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.parser.HclLexicalGrammar;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,10 +31,8 @@ class FileTreeImplTest extends TerraformTreeModelTest {
   @Test
   void empty_file() {
     FileTree tree = parse("", HclLexicalGrammar.FILE);
-    assertThat(tree).isInstanceOfSatisfying(FileTreeImpl.class, f -> {
-      assertThat(f.getKind()).isEqualTo(TerraformTree.Kind.FILE);
-      assertThat(f.body()).isNotPresent();
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.FILE);
+    assertThat(tree.body()).isNotPresent();
   }
 
   @Test

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/ForObjectTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/ForObjectTreeImplTest.java
@@ -20,9 +20,9 @@
 package org.sonar.iac.terraform.tree.impl;
 
 import org.junit.jupiter.api.Test;
-import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.ForObjectTree;
 import org.sonar.iac.terraform.api.tree.LiteralExprTree;
+import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.VariableExprTree;
 import org.sonar.iac.terraform.parser.HclLexicalGrammar;
 
@@ -33,62 +33,54 @@ class ForObjectTreeImplTest extends TerraformTreeModelTest {
   @Test
   void simple_for_tuple() {
     ForObjectTree tree = parse("{for a in b : c => d}", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.FOR_OBJECT);
-      assertThat(o.condition()).isNotPresent();
-      assertThat(o.hasEllipsis()).isFalse();
-      assertThat(o.loopVariables().trees()).hasSize(1);
-      assertThat(o.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("a"));
-      assertThat(o.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
-      assertThat(o.firstExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
-      assertThat(o.secondExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("d"));
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.FOR_OBJECT);
+    assertThat(tree.condition()).isNotPresent();
+    assertThat(tree.hasEllipsis()).isFalse();
+    assertThat(tree.loopVariables().trees()).hasSize(1);
+    assertThat(tree.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("a"));
+    assertThat(tree.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
+    assertThat(tree.firstExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
+    assertThat(tree.secondExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("d"));
   }
 
   @Test
   void with_two_loop_variables() {
     ForObjectTree tree = parse("{for a,b in c : d => e}", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.FOR_OBJECT);
-      assertThat(o.condition()).isNotPresent();
-      assertThat(o.hasEllipsis()).isFalse();
-      assertThat(o.loopVariables().trees()).hasSize(2);
-      assertThat(o.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("a"));
-      assertThat(o.loopVariables().trees().get(1)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
-      assertThat(o.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
-      assertThat(o.firstExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("d"));
-      assertThat(o.secondExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("e"));
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.FOR_OBJECT);
+    assertThat(tree.condition()).isNotPresent();
+    assertThat(tree.hasEllipsis()).isFalse();
+    assertThat(tree.loopVariables().trees()).hasSize(2);
+    assertThat(tree.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("a"));
+    assertThat(tree.loopVariables().trees().get(1)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
+    assertThat(tree.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
+    assertThat(tree.firstExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("d"));
+    assertThat(tree.secondExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("e"));
   }
 
   @Test
   void with_condition() {
     ForObjectTree tree = parse("{for a in b : c => d if true}", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.FOR_OBJECT);
-      assertThat(o.condition()).isPresent();
-      assertThat(o.condition().get()).isInstanceOfSatisfying(LiteralExprTree.class, a -> assertThat(a.value()).isEqualTo("true"));
-      assertThat(o.hasEllipsis()).isFalse();
-      assertThat(o.loopVariables().trees()).hasSize(1);
-      assertThat(o.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("a"));
-      assertThat(o.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
-      assertThat(o.firstExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
-      assertThat(o.secondExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("d"));
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.FOR_OBJECT);
+    assertThat(tree.condition()).isPresent();
+    assertThat(tree.condition().get()).isInstanceOfSatisfying(LiteralExprTree.class, a -> assertThat(a.value()).isEqualTo("true"));
+    assertThat(tree.hasEllipsis()).isFalse();
+    assertThat(tree.loopVariables().trees()).hasSize(1);
+    assertThat(tree.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("a"));
+    assertThat(tree.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
+    assertThat(tree.firstExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
+    assertThat(tree.secondExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("d"));
   }
 
   @Test
   void with_ellipsis() {
     ForObjectTree tree = parse("{for a in b : c => d...}", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.FOR_OBJECT);
-      assertThat(o.condition()).isNotPresent();
-      assertThat(o.hasEllipsis()).isTrue();
-      assertThat(o.loopVariables().trees()).hasSize(1);
-      assertThat(o.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("a"));
-      assertThat(o.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
-      assertThat(o.firstExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
-      assertThat(o.secondExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("d"));
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.FOR_OBJECT);
+    assertThat(tree.condition()).isNotPresent();
+    assertThat(tree.hasEllipsis()).isTrue();
+    assertThat(tree.loopVariables().trees()).hasSize(1);
+    assertThat(tree.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("a"));
+    assertThat(tree.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
+    assertThat(tree.firstExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
+    assertThat(tree.secondExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("d"));
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/ForTupleTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/ForTupleTreeImplTest.java
@@ -20,11 +20,11 @@
 package org.sonar.iac.terraform.tree.impl;
 
 import org.junit.jupiter.api.Test;
+import org.sonar.iac.terraform.api.tree.ForTupleTree;
 import org.sonar.iac.terraform.api.tree.LiteralExprTree;
 import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.VariableExprTree;
 import org.sonar.iac.terraform.parser.HclLexicalGrammar;
-import org.sonar.iac.terraform.api.tree.ForTupleTree;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,41 +33,35 @@ class ForTupleTreeImplTest extends TerraformTreeModelTest {
   @Test
   void simple_for_tuple() {
     ForTupleTree tree = parse("[for a in b : c]", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.FOR_TUPLE);
-      assertThat(o.condition()).isNotPresent();
-      assertThat(o.loopVariables().trees()).hasSize(1);
-      assertThat(o.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("a"));
-      assertThat(o.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
-      assertThat(o.expression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.FOR_TUPLE);
+    assertThat(tree.condition()).isNotPresent();
+    assertThat(tree.loopVariables().trees()).hasSize(1);
+    assertThat(tree.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("a"));
+    assertThat(tree.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
+    assertThat(tree.expression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
   }
 
   @Test
   void with_two_loop_variables() {
     ForTupleTree tree = parse("[for a,b in c : d]", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.FOR_TUPLE);
-      assertThat(o.condition()).isNotPresent();
-      assertThat(o.loopVariables().trees()).hasSize(2);
-      assertThat(o.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("a"));
-      assertThat(o.loopVariables().trees().get(1)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
-      assertThat(o.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
-      assertThat(o.expression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("d"));
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.FOR_TUPLE);
+    assertThat(tree.condition()).isNotPresent();
+    assertThat(tree.loopVariables().trees()).hasSize(2);
+    assertThat(tree.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("a"));
+    assertThat(tree.loopVariables().trees().get(1)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
+    assertThat(tree.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
+    assertThat(tree.expression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("d"));
   }
 
   @Test
   void with_condition() {
     ForTupleTree tree = parse("[for a in b : c if true]", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.FOR_TUPLE);
-      assertThat(o.condition()).isPresent();
-      assertThat(o.condition().get()).isInstanceOfSatisfying(LiteralExprTree.class, a -> assertThat(a.value()).isEqualTo("true"));
-      assertThat(o.loopVariables().trees()).hasSize(1);
-      assertThat(o.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("a"));
-      assertThat(o.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
-      assertThat(o.expression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.FOR_TUPLE);
+    assertThat(tree.condition()).isPresent();
+    assertThat(tree.condition().get()).isInstanceOfSatisfying(LiteralExprTree.class, a -> assertThat(a.value()).isEqualTo("true"));
+    assertThat(tree.loopVariables().trees()).hasSize(1);
+    assertThat(tree.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("a"));
+    assertThat(tree.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
+    assertThat(tree.expression()).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/FunctionCallTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/FunctionCallTreeImplTest.java
@@ -20,11 +20,11 @@
 package org.sonar.iac.terraform.tree.impl;
 
 import org.junit.jupiter.api.Test;
+import org.sonar.iac.terraform.api.tree.FunctionCallTree;
+import org.sonar.iac.terraform.api.tree.SyntaxToken;
 import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.VariableExprTree;
 import org.sonar.iac.terraform.parser.HclLexicalGrammar;
-import org.sonar.iac.terraform.api.tree.FunctionCallTree;
-import org.sonar.iac.terraform.api.tree.SyntaxToken;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -33,38 +33,32 @@ class FunctionCallTreeImplTest extends TerraformTreeModelTest {
   @Test
   void simple_call() {
     FunctionCallTree tree = parse("a(1,2)", HclLexicalGrammar.FUNCTION_CALL);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.FUNCTION_CALL);
-      assertThat(o.name().value()).isEqualTo("a");
-      assertThat(o.arguments().trees()).hasSize(2);
-      assertThat(o.arguments().trees().get(0)).isInstanceOfSatisfying(LiteralExprTreeImpl.class, a -> assertThat(a.value()).isEqualTo("1"));
-      assertThat(o.arguments().trees().get(1)).isInstanceOfSatisfying(LiteralExprTreeImpl.class, a -> assertThat(a.value()).isEqualTo("2"));
-      assertThat(o.arguments().separators()).hasSize(1);
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.FUNCTION_CALL);
+    assertThat(tree.name().value()).isEqualTo("a");
+    assertThat(tree.arguments().trees()).hasSize(2);
+    assertThat(tree.arguments().trees().get(0)).isInstanceOfSatisfying(LiteralExprTreeImpl.class, a -> assertThat(a.value()).isEqualTo("1"));
+    assertThat(tree.arguments().trees().get(1)).isInstanceOfSatisfying(LiteralExprTreeImpl.class, a -> assertThat(a.value()).isEqualTo("2"));
+    assertThat(tree.arguments().separators()).hasSize(1);
   }
 
   @Test
   void trailing_comma() {
     FunctionCallTree tree = parse("a(1,)", HclLexicalGrammar.FUNCTION_CALL);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.name().value()).isEqualTo("a");
-      assertThat(o.arguments().trees()).hasSize(1);
-      assertThat(o.arguments().trees().get(0)).isInstanceOfSatisfying(LiteralExprTreeImpl.class, a -> assertThat(a.value()).isEqualTo("1"));
-      assertThat(o.arguments().separators()).hasSize(1);
-    });
+    assertThat(tree.name().value()).isEqualTo("a");
+    assertThat(tree.arguments().trees()).hasSize(1);
+    assertThat(tree.arguments().trees().get(0)).isInstanceOfSatisfying(LiteralExprTreeImpl.class, a -> assertThat(a.value()).isEqualTo("1"));
+    assertThat(tree.arguments().separators()).hasSize(1);
   }
 
   @Test
   void trailing_ellipsis_operator() {
     FunctionCallTree tree = parse("a(b,c...)", HclLexicalGrammar.FUNCTION_CALL);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.name().value()).isEqualTo("a");
-      assertThat(o.arguments().trees()).hasSize(2);
-      assertThat(o.arguments().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
-      assertThat(o.arguments().trees().get(1)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
-      assertThat(o.arguments().separators()).hasSize(2);
-      assertThat(o.arguments().separators().get(0)).isInstanceOfSatisfying(SyntaxToken.class, a -> assertThat(a.value()).isEqualTo(","));
-      assertThat(o.arguments().separators().get(1)).isInstanceOfSatisfying(SyntaxToken.class, a -> assertThat(a.value()).isEqualTo("..."));
-    });
+    assertThat(tree.name().value()).isEqualTo("a");
+    assertThat(tree.arguments().trees()).hasSize(2);
+    assertThat(tree.arguments().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("b"));
+    assertThat(tree.arguments().trees().get(1)).isInstanceOfSatisfying(VariableExprTree.class, a -> assertThat(a.name()).isEqualTo("c"));
+    assertThat(tree.arguments().separators()).hasSize(2);
+    assertThat(tree.arguments().separators().get(0)).isInstanceOfSatisfying(SyntaxToken.class, a -> assertThat(a.value()).isEqualTo(","));
+    assertThat(tree.arguments().separators().get(1)).isInstanceOfSatisfying(SyntaxToken.class, a -> assertThat(a.value()).isEqualTo("..."));
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/IndexAccessExprTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/IndexAccessExprTreeImplTest.java
@@ -20,46 +20,41 @@
 package org.sonar.iac.terraform.tree.impl;
 
 import org.junit.jupiter.api.Test;
-import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.IndexAccessExprTree;
+import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.parser.HclLexicalGrammar;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class IndexAccessExprTreeImplTest extends TerraformTreeModelTest {
+
   @Test
   void simple_index_access() {
     IndexAccessExprTree tree = parse("a[1]", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(a -> {
-      assertThat(a.getKind()).isEqualTo(TerraformTree.Kind.INDEX_ACCESS_EXPR);
-      assertThat(a.subject()).isInstanceOfSatisfying(VariableExprTreeImpl.class, o -> assertThat(o.name()).isEqualTo("a"));
-      assertThat(a.index()).isInstanceOfSatisfying(LiteralExprTreeImpl.class, o -> assertThat(o.value()).isEqualTo("1"));
-      assertThat(a.children()).hasSize(4);
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.INDEX_ACCESS_EXPR);
+    assertThat(tree.subject()).isInstanceOfSatisfying(VariableExprTreeImpl.class, o -> assertThat(o.name()).isEqualTo("a"));
+    assertThat(tree.index()).isInstanceOfSatisfying(LiteralExprTreeImpl.class, o -> assertThat(o.value()).isEqualTo("1"));
+    assertThat(tree.children()).hasSize(4);
   }
 
   @Test
   void double_index_access() {
     IndexAccessExprTree tree = parse("a[1][2]", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(a -> {
-      assertThat(a.subject()).isInstanceOfSatisfying(IndexAccessExprTreeImpl.class, o -> {
-        assertThat(o.subject()).isInstanceOfSatisfying(VariableExprTreeImpl.class, ob -> assertThat(ob.name()).isEqualTo("a"));
-        assertThat(o.index()).isInstanceOfSatisfying(LiteralExprTreeImpl.class, ob -> assertThat(ob.value()).isEqualTo("1"));
-        assertThat(o.index()).isInstanceOfSatisfying(LiteralExprTreeImpl.class, ob -> assertThat(ob.value()).isEqualTo("1"));
-      });
-      assertThat(a.index()).isInstanceOfSatisfying(LiteralExprTreeImpl.class, o -> assertThat(o.value()).isEqualTo("2"));
+    assertThat(tree.subject()).isInstanceOfSatisfying(IndexAccessExprTreeImpl.class, o -> {
+      assertThat(o.subject()).isInstanceOfSatisfying(VariableExprTreeImpl.class, ob -> assertThat(ob.name()).isEqualTo("a"));
+      assertThat(o.index()).isInstanceOfSatisfying(LiteralExprTreeImpl.class, ob -> assertThat(ob.value()).isEqualTo("1"));
+      assertThat(o.index()).isInstanceOfSatisfying(LiteralExprTreeImpl.class, ob -> assertThat(ob.value()).isEqualTo("1"));
     });
+    assertThat(tree.index()).isInstanceOfSatisfying(LiteralExprTreeImpl.class, o -> assertThat(o.value()).isEqualTo("2"));
   }
 
   @Test
   void attribute_access_subject() {
     IndexAccessExprTree tree = parse("a.b[1]", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(a -> {
-      assertThat(a.subject()).isInstanceOfSatisfying(AttributeAccessTreeImpl.class, o -> {
-        assertThat(o.object()).isInstanceOfSatisfying(VariableExprTreeImpl.class, ob -> assertThat(ob.name()).isEqualTo("a"));
-        assertThat(o.attribute().value()).isEqualTo("b");
-      });
-      assertThat(a.index()).isInstanceOfSatisfying(LiteralExprTreeImpl.class, o -> assertThat(o.value()).isEqualTo("1"));
+    assertThat(tree.subject()).isInstanceOfSatisfying(AttributeAccessTreeImpl.class, o -> {
+      assertThat(o.object()).isInstanceOfSatisfying(VariableExprTreeImpl.class, ob -> assertThat(ob.name()).isEqualTo("a"));
+      assertThat(o.attribute().value()).isEqualTo("b");
     });
+    assertThat(tree.index()).isInstanceOfSatisfying(LiteralExprTreeImpl.class, o -> assertThat(o.value()).isEqualTo("1"));
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/IndexSplatAccessTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/IndexSplatAccessTreeImplTest.java
@@ -31,10 +31,8 @@ class IndexSplatAccessTreeImplTest extends TerraformTreeModelTest {
   @Test
   void simple_index_splat_access() {
     IndexSplatAccessTree tree = parse("a[*]", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(a -> {
-      assertThat(a.getKind()).isEqualTo(TerraformTree.Kind.INDEX_SPLAT_ACCESS);
-      assertThat(a.children()).hasSize(4);
-      assertThat(a.subject()).isInstanceOfSatisfying(VariableExprTreeImpl.class, o -> assertThat(o.name()).isEqualTo("a"));
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.INDEX_SPLAT_ACCESS);
+    assertThat(tree.children()).hasSize(4);
+    assertThat(tree.subject()).isInstanceOfSatisfying(VariableExprTreeImpl.class, o -> assertThat(o.name()).isEqualTo("a"));
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/LabelTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/LabelTreeImplTest.java
@@ -20,29 +20,26 @@
 package org.sonar.iac.terraform.tree.impl;
 
 import org.junit.jupiter.api.Test;
-import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.LabelTree;
+import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.parser.HclLexicalGrammar;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class LabelTreeImplTest extends TerraformTreeModelTest {
+
   @Test
   void string_literal() {
     LabelTree tree = parse("\"a\"", HclLexicalGrammar.LABEL);
-    assertThat(tree).isInstanceOfSatisfying(LabelTreeImpl.class, o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.LABEL);
-      assertThat(o.value()).isEqualTo("\"a\"");
-      assertThat(o.value()).isEqualTo(o.token().value());
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.LABEL);
+    assertThat(tree.value()).isEqualTo("\"a\"");
+    assertThat(tree.value()).isEqualTo(tree.token().value());
   }
 
   @Test
   void identifier() {
     LabelTree tree = parse("id", HclLexicalGrammar.LABEL);
-    assertThat(tree).isInstanceOfSatisfying(LabelTreeImpl.class, o -> {
-      assertThat(o.value()).isEqualTo("id");
-      assertThat(o.value()).isEqualTo(o.token().value());
-    });
+    assertThat(tree.value()).isEqualTo("id");
+    assertThat(tree.value()).isEqualTo(tree.token().value());
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/LiteralExprTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/LiteralExprTreeImplTest.java
@@ -20,8 +20,8 @@
 package org.sonar.iac.terraform.tree.impl;
 
 import org.junit.jupiter.api.Test;
-import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.LiteralExprTree;
+import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.parser.HclLexicalGrammar;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,37 +31,29 @@ class LiteralExprTreeImplTest extends TerraformTreeModelTest {
   @Test
   void boolean_literal() {
     LiteralExprTree tree = parse("true", HclLexicalGrammar.LITERAL_EXPRESSION);
-    assertThat(tree).isInstanceOfSatisfying(LiteralExprTreeImpl.class, o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.BOOLEAN_LITERAL);
-      assertThat(o.is(TerraformTree.Kind.BOOLEAN_LITERAL)).isTrue();
-      assertThat(o.value()).isEqualTo("true");
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.BOOLEAN_LITERAL);
+    assertThat(tree.is(TerraformTree.Kind.BOOLEAN_LITERAL)).isTrue();
+    assertThat(tree.value()).isEqualTo("true");
   }
 
   @Test
   void null_literal() {
     LiteralExprTree tree = parse("null", HclLexicalGrammar.LITERAL_EXPRESSION);
-    assertThat(tree).isInstanceOfSatisfying(LiteralExprTreeImpl.class, o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.NULL_LITERAL);
-      assertThat(o.value()).isEqualTo("null");
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.NULL_LITERAL);
+    assertThat(tree.value()).isEqualTo("null");
   }
 
   @Test
   void numeric_literal() {
     LiteralExprTree tree = parse("1", HclLexicalGrammar.LITERAL_EXPRESSION);
-    assertThat(tree).isInstanceOfSatisfying(LiteralExprTreeImpl.class, o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.NUMERIC_LITERAL);
-      assertThat(o.value()).isEqualTo("1");
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.NUMERIC_LITERAL);
+    assertThat(tree.value()).isEqualTo("1");
   }
 
   @Test
   void heredoc_literal() {
     LiteralExprTree tree = parse("<<EOF\nfoo\nEOF", HclLexicalGrammar.LITERAL_EXPRESSION);
-    assertThat(tree).isInstanceOfSatisfying(LiteralExprTreeImpl.class, o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.HEREDOC_LITERAL);
-      assertThat(o.value()).isEqualTo("<<EOF\nfoo\nEOF");
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.HEREDOC_LITERAL);
+    assertThat(tree.value()).isEqualTo("<<EOF\nfoo\nEOF");
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/ObjectElementTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/ObjectElementTreeImplTest.java
@@ -31,11 +31,9 @@ class ObjectElementTreeImplTest extends TerraformTreeModelTest {
   @Test
   void simple_element() {
     ObjectElementTree tree = parse("a : 1", HclLexicalGrammar.OBJECT_ELEMENT);
-    assertThat(tree).isInstanceOfSatisfying(ObjectElementTreeImpl.class, o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.OBJECT_ELEMENT);
-      assertThat(o.name()).isInstanceOfSatisfying(VariableExprTreeImpl.class, n -> assertThat(n.name()).isEqualTo("a"));
-      assertThat(o.equalOrColonSign()).isInstanceOfSatisfying(SyntaxTokenImpl.class, n -> assertThat(n.value()).isEqualTo(":"));
-      assertThat(o.value()).isInstanceOfSatisfying(LiteralExprTreeImpl.class, n -> assertThat(n.value()).isEqualTo("1"));
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.OBJECT_ELEMENT);
+    assertThat(tree.name()).isInstanceOfSatisfying(VariableExprTreeImpl.class, n -> assertThat(n.name()).isEqualTo("a"));
+    assertThat(tree.equalOrColonSign()).isInstanceOfSatisfying(SyntaxTokenImpl.class, n -> assertThat(n.value()).isEqualTo(":"));
+    assertThat(tree.value()).isInstanceOfSatisfying(LiteralExprTreeImpl.class, n -> assertThat(n.value()).isEqualTo("1"));
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/ObjectTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/ObjectTreeImplTest.java
@@ -31,10 +31,8 @@ class ObjectTreeImplTest extends TerraformTreeModelTest {
   @Test
   void simple_object() {
     ObjectTree tree = parse("{a: 1, b: 2}", HclLexicalGrammar.OBJECT);
-    assertThat(tree).isInstanceOfSatisfying(ObjectTreeImpl.class, o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.OBJECT);
-      assertThat(o.elements().trees()).hasSize(2);
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.OBJECT);
+    assertThat(tree.elements().trees()).hasSize(2);
   }
 
   @Test

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/OneLineBlockTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/OneLineBlockTreeImplTest.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.iac.terraform.tree.impl;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.sonar.iac.terraform.api.tree.OneLineBlockTree;
 import org.sonar.iac.terraform.api.tree.TerraformTree;
@@ -33,123 +32,103 @@ class OneLineBlockTreeImplTest extends TerraformTreeModelTest {
   @Test
   void simple_one_line_block() {
     OneLineBlockTree tree = parse("a {}", HclLexicalGrammar.ONE_LINE_BLOCK);
-    assertThat(tree).isInstanceOfSatisfying(OneLineBlockTreeImpl.class, o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.ONE_LINE_BLOCK);
-      assertThat(o.type().value()).isEqualTo("a");
-      Assertions.assertThat(o.labels()).isEmpty();
-      assertThat(o.attribute()).isNotPresent();
-      assertTextRange(o.textRange()).hasRange(1,0,1,4);
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.ONE_LINE_BLOCK);
+    assertThat(tree.type().value()).isEqualTo("a");
+    assertThat(tree.labels()).isEmpty();
+    assertThat(tree.attribute()).isNotPresent();
+    assertTextRange(tree.textRange()).hasRange(1,0,1,4);
   }
 
   @Test
   void with_string_label() {
     OneLineBlockTree tree = parse("a \"label\" {}", HclLexicalGrammar.ONE_LINE_BLOCK);
-    assertThat(tree).isInstanceOfSatisfying(OneLineBlockTreeImpl.class, o -> {
-      assertThat(o.type().value()).isEqualTo("a");
-      Assertions.assertThat(o.labels()).hasSize(1);
-      Assertions.assertThat(o.labels().get(0).value()).isEqualTo("\"label\"");
-    });
+    assertThat(tree.type().value()).isEqualTo("a");
+    assertThat(tree.labels()).hasSize(1);
+    assertThat(tree.labels().get(0).value()).isEqualTo("\"label\"");
   }
 
   @Test
   void with_multiple_strings_labels() {
     OneLineBlockTree tree = parse("a \"label1\" \"label2\" {}", HclLexicalGrammar.ONE_LINE_BLOCK);
-    assertThat(tree).isInstanceOfSatisfying(OneLineBlockTreeImpl.class, o -> {
-      assertThat(o.type().value()).isEqualTo("a");
-      Assertions.assertThat(o.labels()).hasSize(2);
-      Assertions.assertThat(o.labels().get(0).value()).isEqualTo("\"label1\"");
-      Assertions.assertThat(o.labels().get(1).value()).isEqualTo("\"label2\"");
-    });
+    assertThat(tree.type().value()).isEqualTo("a");
+    assertThat(tree.labels()).hasSize(2);
+    assertThat(tree.labels().get(0).value()).isEqualTo("\"label1\"");
+    assertThat(tree.labels().get(1).value()).isEqualTo("\"label2\"");
   }
 
   @Test
   void with_string_and_identifier_labels() {
     OneLineBlockTree tree = parse("a \"label1\" label2 {}", HclLexicalGrammar.ONE_LINE_BLOCK);
-    assertThat(tree).isInstanceOfSatisfying(OneLineBlockTreeImpl.class, o -> {
-      assertThat(o.type().value()).isEqualTo("a");
-      Assertions.assertThat(o.labels()).hasSize(2);
-      Assertions.assertThat(o.labels().get(0).value()).isEqualTo("\"label1\"");
-      Assertions.assertThat(o.labels().get(1).value()).isEqualTo("label2");
-    });
+    assertThat(tree.type().value()).isEqualTo("a");
+    assertThat(tree.labels()).hasSize(2);
+    assertThat(tree.labels().get(0).value()).isEqualTo("\"label1\"");
+    assertThat(tree.labels().get(1).value()).isEqualTo("label2");
   }
 
   @Test
   void with_simple_attribute() {
     OneLineBlockTree tree = parse("a { b = true }", HclLexicalGrammar.ONE_LINE_BLOCK);
-    assertThat(tree).isInstanceOfSatisfying(OneLineBlockTreeImpl.class, o -> {
-      assertThat(o.type().value()).isEqualTo("a");
-      Assertions.assertThat(o.labels()).isEmpty();
-      assertThat(o.attribute().get()).isInstanceOf(AttributeTreeImpl.class);
-    });
+    assertThat(tree.type().value()).isEqualTo("a");
+    assertThat(tree.labels()).isEmpty();
+    assertThat(tree.attribute().get()).isInstanceOf(AttributeTreeImpl.class);
   }
 
   @Test
   void with_singleline_comment1() {
     OneLineBlockTree tree = parse("#comment\na {}", HclLexicalGrammar.ONE_LINE_BLOCK);
-    assertThat(tree).isInstanceOfSatisfying(OneLineBlockTreeImpl.class, o -> {
-      assertThat(o.type().value()).isEqualTo("a");
-      assertThat(o.type().comments()).hasSize(1);
-      assertThat(o.type().comments().get(0)).satisfies(t -> {
-        assertThat(t.value()).isEqualTo("#comment");
-        assertTextRange(t.textRange()).hasRange(1,0,1,8);
-      });
+    assertThat(tree.type().value()).isEqualTo("a");
+    assertThat(tree.type().comments()).hasSize(1);
+    assertThat(tree.type().comments().get(0)).satisfies(t -> {
+      assertThat(t.value()).isEqualTo("#comment");
+      assertTextRange(t.textRange()).hasRange(1,0,1,8);
     });
   }
 
   @Test
   void with_singleline_comment2() {
     OneLineBlockTree tree = parse("//comment\na {}", HclLexicalGrammar.ONE_LINE_BLOCK);
-    assertThat(tree).isInstanceOfSatisfying(OneLineBlockTreeImpl.class, o -> {
-      assertThat(o.type().value()).isEqualTo("a");
-      assertThat(o.type().comments()).hasSize(1);
-      assertThat(o.type().comments().get(0)).satisfies(t -> {
-        assertThat(t.value()).isEqualTo("//comment");
-        assertTextRange(t.textRange()).hasRange(1,0,1,9);
-      });
+    assertThat(tree.type().value()).isEqualTo("a");
+    assertThat(tree.type().comments()).hasSize(1);
+    assertThat(tree.type().comments().get(0)).satisfies(t -> {
+      assertThat(t.value()).isEqualTo("//comment");
+      assertTextRange(t.textRange()).hasRange(1,0,1,9);
     });
   }
 
   @Test
   void with_multiple_singleline_comment() {
     OneLineBlockTree tree = parse("#comment1\n#comment2\na {}", HclLexicalGrammar.ONE_LINE_BLOCK);
-    assertThat(tree).isInstanceOfSatisfying(OneLineBlockTreeImpl.class, o -> {
-      assertThat(o.type().value()).isEqualTo("a");
-      assertThat(o.type().comments()).hasSize(2);
-      assertThat(o.type().comments().get(0)).satisfies(t -> {
-        assertThat(t.value()).isEqualTo("#comment1");
-        assertTextRange(t.textRange()).hasRange(1,0,1,9);
-      });
-      assertThat(o.type().comments().get(1)).satisfies(t -> {
-        assertThat(t.value()).isEqualTo("#comment2");
-        assertTextRange(t.textRange()).hasRange(2,0,2,9);
-      });
+    assertThat(tree.type().value()).isEqualTo("a");
+    assertThat(tree.type().comments()).hasSize(2);
+    assertThat(tree.type().comments().get(0)).satisfies(t -> {
+      assertThat(t.value()).isEqualTo("#comment1");
+      assertTextRange(t.textRange()).hasRange(1,0,1,9);
+    });
+    assertThat(tree.type().comments().get(1)).satisfies(t -> {
+      assertThat(t.value()).isEqualTo("#comment2");
+      assertTextRange(t.textRange()).hasRange(2,0,2,9);
     });
   }
 
   @Test
   void with_multiline_comment() {
     OneLineBlockTree tree = parse("/* line1\nline2 */\na {}", HclLexicalGrammar.ONE_LINE_BLOCK);
-    assertThat(tree).isInstanceOfSatisfying(OneLineBlockTreeImpl.class, o -> {
-      assertThat(o.type().value()).isEqualTo("a");
-      assertThat(o.type().comments()).hasSize(1);
-      assertThat(o.type().comments().get(0)).satisfies(t -> {
-        assertThat(t.value()).isEqualTo("/* line1\nline2 */");
-        assertTextRange(t.textRange()).hasRange(1,0,2,8);
-      });
+    assertThat(tree.type().value()).isEqualTo("a");
+    assertThat(tree.type().comments()).hasSize(1);
+    assertThat(tree.type().comments().get(0)).satisfies(t -> {
+      assertThat(t.value()).isEqualTo("/* line1\nline2 */");
+      assertTextRange(t.textRange()).hasRange(1,0,2,8);
     });
   }
 
   @Test
   void with_multiline_comment_same_line() {
     OneLineBlockTree tree = parse("/* comment */a {}", HclLexicalGrammar.ONE_LINE_BLOCK);
-    assertThat(tree).isInstanceOfSatisfying(OneLineBlockTreeImpl.class, o -> {
-      assertThat(o.type().value()).isEqualTo("a");
-      assertThat(o.type().comments()).hasSize(1);
-      assertThat(o.type().comments().get(0)).satisfies(t -> {
-        assertThat(t.value()).isEqualTo("/* comment */");
-        assertTextRange(t.textRange()).hasRange(1,0,1,13);
-      });
+    assertThat(tree.type().value()).isEqualTo("a");
+    assertThat(tree.type().comments()).hasSize(1);
+    assertThat(tree.type().comments().get(0)).satisfies(t -> {
+      assertThat(t.value()).isEqualTo("/* comment */");
+      assertTextRange(t.textRange()).hasRange(1,0,1,13);
     });
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/ParenthesizedExpressionTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/ParenthesizedExpressionTreeImplTest.java
@@ -20,8 +20,8 @@
 package org.sonar.iac.terraform.tree.impl;
 
 import org.junit.jupiter.api.Test;
-import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.ParenthesizedExpressionTree;
+import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.VariableExprTree;
 import org.sonar.iac.terraform.parser.HclLexicalGrammar;
 
@@ -32,10 +32,8 @@ class ParenthesizedExpressionTreeImplTest extends TerraformTreeModelTest {
   @Test
   void simple_parenthesized_expression() {
     ParenthesizedExpressionTree tree = parse("(a)", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.PARENTHESIZED_EXPRESSION);
-      assertThat(o.children()).hasSize(3);
-      assertThat(o.expression()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("a"));
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.PARENTHESIZED_EXPRESSION);
+    assertThat(tree.children()).hasSize(3);
+    assertThat(tree.expression()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("a"));
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/PrefixExpressionTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/PrefixExpressionTreeImplTest.java
@@ -20,10 +20,10 @@
 package org.sonar.iac.terraform.tree.impl;
 
 import org.junit.jupiter.api.Test;
-import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.PrefixExpressionTree;
-import org.sonar.iac.terraform.api.tree.VariableExprTree;
 import org.sonar.iac.terraform.api.tree.SyntaxToken;
+import org.sonar.iac.terraform.api.tree.TerraformTree;
+import org.sonar.iac.terraform.api.tree.VariableExprTree;
 import org.sonar.iac.terraform.parser.HclLexicalGrammar;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,23 +33,19 @@ class PrefixExpressionTreeImplTest extends TerraformTreeModelTest {
   @Test
   void single_prefix() {
     PrefixExpressionTree tree = parse("!a", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.PREFIX_EXPRESSION);
-      assertThat(o.children()).hasSize(2);
-      assertThat(o.prefix()).isInstanceOfSatisfying(SyntaxToken.class, v -> assertThat(v.value()).isEqualTo("!"));
-      assertThat(o.expression()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("a"));
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.PREFIX_EXPRESSION);
+    assertThat(tree.children()).hasSize(2);
+    assertThat(tree.prefix()).isInstanceOfSatisfying(SyntaxToken.class, v -> assertThat(v.value()).isEqualTo("!"));
+    assertThat(tree.expression()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("a"));
   }
 
   @Test
   void multiple_prefixes_order() {
     PrefixExpressionTree tree = parse("-!a", HclLexicalGrammar.EXPRESSION);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.prefix()).isInstanceOfSatisfying(SyntaxToken.class, v -> assertThat(v.value()).isEqualTo("-"));
-      assertThat(o.expression()).isInstanceOfSatisfying(PrefixExpressionTree.class, p -> {
-        assertThat(p.prefix()).isInstanceOfSatisfying(SyntaxToken.class, v -> assertThat(v.value()).isEqualTo("!"));
-        assertThat(p.expression()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("a"));
-      });
+    assertThat(tree.prefix()).isInstanceOfSatisfying(SyntaxToken.class, v -> assertThat(v.value()).isEqualTo("-"));
+    assertThat(tree.expression()).isInstanceOfSatisfying(PrefixExpressionTree.class, p -> {
+      assertThat(p.prefix()).isInstanceOfSatisfying(SyntaxToken.class, v -> assertThat(v.value()).isEqualTo("!"));
+      assertThat(p.expression()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("a"));
     });
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/SeparatedTreesImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/SeparatedTreesImplTest.java
@@ -19,23 +19,22 @@
  */
 package org.sonar.iac.terraform.tree.impl;
 
-import org.junit.jupiter.api.Test;
-import org.sonar.iac.terraform.api.tree.TerraformTree;
-import org.sonar.iac.terraform.api.tree.SyntaxToken;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.iac.terraform.api.tree.SyntaxToken;
+import org.sonar.iac.terraform.api.tree.TerraformTree;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SeparatedTreesImplTest {
-  private static TerraformTree treeA = new SyntaxTokenImpl("a", null, null);
-  private static TerraformTree treeB = new SyntaxTokenImpl("b", null, null);
-  private static List<TerraformTree> elementsList = Arrays.asList(treeA, treeB);
-  private static SyntaxToken separator = new SyntaxTokenImpl(",", null, null);
-  private static SeparatedTreesImpl<TerraformTree> list = new SeparatedTreesImpl<>(elementsList, Arrays.asList(separator));
+  private static final TerraformTree treeA = new SyntaxTokenImpl("a", null, null);
+  private static final TerraformTree treeB = new SyntaxTokenImpl("b", null, null);
+  private static final List<TerraformTree> elementsList = Arrays.asList(treeA, treeB);
+  private static final SyntaxToken separator = new SyntaxTokenImpl(",", null, null);
+  private static final SeparatedTreesImpl<TerraformTree> list = new SeparatedTreesImpl<>(elementsList, Collections.singletonList(separator));
 
   @Test
   void empty() {
@@ -54,7 +53,7 @@ class SeparatedTreesImplTest {
   @Test
   void wrong_arguments() {
     List<TerraformTree> elements = Collections.emptyList();
-    List<SyntaxToken> separators = Arrays.asList(separator);
+    List<SyntaxToken> separators = Collections.singletonList(separator);
     assertThatThrownBy(() -> new SeparatedTreesImpl<>(elements, separators)).isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/TemplateExpressionTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/TemplateExpressionTreeImplTest.java
@@ -19,14 +19,13 @@
  */
 package org.sonar.iac.terraform.tree.impl;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.sonar.iac.terraform.api.tree.TemplateExpressionTree;
-import org.sonar.iac.terraform.api.tree.TemplateIfDirectiveTree;
-import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.BinaryExpressionTree;
 import org.sonar.iac.terraform.api.tree.LiteralExprTree;
+import org.sonar.iac.terraform.api.tree.TemplateExpressionTree;
 import org.sonar.iac.terraform.api.tree.TemplateForDirectiveTree;
+import org.sonar.iac.terraform.api.tree.TemplateIfDirectiveTree;
+import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.VariableExprTree;
 import org.sonar.iac.terraform.parser.HclLexicalGrammar;
 
@@ -37,72 +36,62 @@ class TemplateExpressionTreeImplTest extends TerraformTreeModelTest {
   @Test
   void literal_tree_is_produced_when_no_interpolation_exists() {
     LiteralExprTree tree = parse("\"abc\"", HclLexicalGrammar.QUOTED_TEMPLATE);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.STRING_LITERAL);
-      assertThat(o.value()).isEqualTo("abc");
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.STRING_LITERAL);
+    assertThat(tree.value()).isEqualTo("abc");
   }
 
   @Test
   void simple_quoted_interpolation() {
     TemplateExpressionTree tree = parse("\"ab${x}\"", HclLexicalGrammar.QUOTED_TEMPLATE);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_EXPRESSION);
-      Assertions.assertThat(o.parts()).hasSize(2);
-      assertThat(o.parts().get(0)).isInstanceOfSatisfying(LiteralExprTree.class, p -> {
-        assertThat(p.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_STRING_PART_LITERAL);
-        assertThat(p.value()).isEqualTo("ab");
-      });
-      assertThat(o.parts().get(1)).isInstanceOfSatisfying(TemplateInterpolationTreeImpl.class, p -> {
-        assertThat(p.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_INTERPOLATION);
-        assertThat(p.expression()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("x"));
-      });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_EXPRESSION);
+    assertThat(tree.parts()).hasSize(2);
+    assertThat(tree.parts().get(0)).isInstanceOfSatisfying(LiteralExprTree.class, p -> {
+      assertThat(p.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_STRING_PART_LITERAL);
+      assertThat(p.value()).isEqualTo("ab");
+    });
+    assertThat(tree.parts().get(1)).isInstanceOfSatisfying(TemplateInterpolationTreeImpl.class, p -> {
+      assertThat(p.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_INTERPOLATION);
+      assertThat(p.expression()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("x"));
     });
   }
 
   @Test
   void simple_quoted_if_directive() {
     TemplateExpressionTree tree = parse("\"%{ if a != 1 }foo%{ else }bar%{ endif }\"", HclLexicalGrammar.QUOTED_TEMPLATE);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_EXPRESSION);
-      Assertions.assertThat(o.parts()).hasSize(1);
-      assertThat(o.parts().get(0)).isInstanceOfSatisfying(TemplateIfDirectiveTree.class, p -> {
-        assertThat(p.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_DIRECTIVE_IF);
-        assertThat(p.condition()).isInstanceOf(BinaryExpressionTree.class);
-        assertThat(p.trueExpression()).isInstanceOfSatisfying(LiteralExprTree.class, l -> assertThat(l.value()).isEqualTo("foo"));
-        assertThat(p.falseExpression()).isInstanceOfSatisfying(LiteralExprTree.class, l -> assertThat(l.value()).isEqualTo("bar"));
-      });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_EXPRESSION);
+    assertThat(tree.parts()).hasSize(1);
+    assertThat(tree.parts().get(0)).isInstanceOfSatisfying(TemplateIfDirectiveTree.class, p -> {
+      assertThat(p.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_DIRECTIVE_IF);
+      assertThat(p.condition()).isInstanceOf(BinaryExpressionTree.class);
+      assertThat(p.trueExpression()).isInstanceOfSatisfying(LiteralExprTree.class, l -> assertThat(l.value()).isEqualTo("foo"));
+      assertThat(p.falseExpression()).isInstanceOfSatisfying(LiteralExprTree.class, l -> assertThat(l.value()).isEqualTo("bar"));
     });
   }
 
   @Test
   void quoted_if_directive_without_else() {
     TemplateExpressionTree tree = parse("\"%{ if a != 1 }foo%{ endif }\"", HclLexicalGrammar.QUOTED_TEMPLATE);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_EXPRESSION);
-      Assertions.assertThat(o.parts()).hasSize(1);
-      assertThat(o.parts().get(0)).isInstanceOfSatisfying(TemplateIfDirectiveTree.class, p -> {
-        assertThat(p.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_DIRECTIVE_IF);
-        assertThat(p.condition()).isInstanceOf(BinaryExpressionTree.class);
-        assertThat(p.trueExpression()).isInstanceOfSatisfying(LiteralExprTree.class, l -> assertThat(l.value()).isEqualTo("foo"));
-        assertThat(p.falseExpression()).isNull();
-      });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_EXPRESSION);
+    assertThat(tree.parts()).hasSize(1);
+    assertThat(tree.parts().get(0)).isInstanceOfSatisfying(TemplateIfDirectiveTree.class, p -> {
+      assertThat(p.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_DIRECTIVE_IF);
+      assertThat(p.condition()).isInstanceOf(BinaryExpressionTree.class);
+      assertThat(p.trueExpression()).isInstanceOfSatisfying(LiteralExprTree.class, l -> assertThat(l.value()).isEqualTo("foo"));
+      assertThat(p.falseExpression()).isNull();
     });
   }
 
   @Test
   void simple_quoted_for_directive() {
     TemplateExpressionTree tree = parse("\"%{ for a in b}foo%{ endfor }\"", HclLexicalGrammar.QUOTED_TEMPLATE);
-    assertThat(tree).satisfies(o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_EXPRESSION);
-      Assertions.assertThat(o.parts()).hasSize(1);
-      assertThat(o.parts().get(0)).isInstanceOfSatisfying(TemplateForDirectiveTree.class, p -> {
-        assertThat(p.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_DIRECTIVE_FOR);
-        assertThat(p.loopVariables().treesAndSeparators()).hasSize(1);
-        assertThat(p.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("a"));
-        assertThat(p.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("b"));
-        assertThat(p.expression()).isInstanceOfSatisfying(LiteralExprTree.class, l -> assertThat(l.value()).isEqualTo("foo"));
-      });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_EXPRESSION);
+    assertThat(tree.parts()).hasSize(1);
+    assertThat(tree.parts().get(0)).isInstanceOfSatisfying(TemplateForDirectiveTree.class, p -> {
+      assertThat(p.getKind()).isEqualTo(TerraformTree.Kind.TEMPLATE_DIRECTIVE_FOR);
+      assertThat(p.loopVariables().treesAndSeparators()).hasSize(1);
+      assertThat(p.loopVariables().trees().get(0)).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("a"));
+      assertThat(p.loopExpression()).isInstanceOfSatisfying(VariableExprTree.class, v -> assertThat(v.name()).isEqualTo("b"));
+      assertThat(p.expression()).isInstanceOfSatisfying(LiteralExprTree.class, l -> assertThat(l.value()).isEqualTo("foo"));
     });
   }
 }

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/TupleTreeImplTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/tree/impl/TupleTreeImplTest.java
@@ -31,10 +31,8 @@ class TupleTreeImplTest extends TerraformTreeModelTest {
   @Test
   void simple_tuple() {
     TupleTree tree = parse("[a, b]", HclLexicalGrammar.TUPLE);
-    assertThat(tree).isInstanceOfSatisfying(TupleTreeImpl.class, o -> {
-      assertThat(o.getKind()).isEqualTo(TerraformTree.Kind.TUPLE);
-      assertThat(o.elements().trees()).hasSize(2);
-      assertThat(o.children()).hasSize(5);
-    });
+    assertThat(tree.getKind()).isEqualTo(TerraformTree.Kind.TUPLE);
+    assertThat(tree.elements().trees()).hasSize(2);
+    assertThat(tree.children()).hasSize(5);
   }
 }


### PR DESCRIPTION
This PR is purely refactoring in the Trees UTs folder for terraform. It does mainly the following:

- Remove unnecessary usage of `satisfies()`
- Reorder imports according to our import style rules.