### PR TITLE
Remove org.sonar.api.internal usage

### DIFF
--- a/iac-extensions/cloudformation/src/main/java/org/sonar/iac/cloudformation/checks/LogGroupDeclarationCheck.java
+++ b/iac-extensions/cloudformation/src/main/java/org/sonar/iac/cloudformation/checks/LogGroupDeclarationCheck.java
@@ -15,7 +15,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.sonar.api.internal.apachecommons.lang.StringUtils;
 import org.sonar.check.Rule;
 import org.sonar.iac.cloudformation.api.tree.CloudformationTree;
 import org.sonar.iac.cloudformation.api.tree.FileTree;
@@ -77,7 +76,8 @@ public class LogGroupDeclarationCheck implements IacCheck {
     // We have to check the tag type and not the property value instance due to some functions are also represented as ScalarTrees
     if (property.tag().endsWith("str")) {
       // extract function name from LogGroupName (e.g /aws/lambda/my-function-name -> my-function-name)
-      return Collections.singleton(StringUtils.substringAfterLast(((ScalarTree) property).value(), "/"));
+      String value = ((ScalarTree) property).value();
+      return Collections.singleton(value.substring(value.lastIndexOf("/") + 1));
     }
     return FunctionReferenceCollector.get(property);
   }


### PR DESCRIPTION
This led to a crash on peach with 
```
ERROR: Error during SonarScanner execution
java.lang.NoClassDefFoundError: org/sonar/api/internal/apachecommons/lang/StringUtils
        at org.sonar.iac.cloudformation.checks.LogGroupDeclarationCheck.resolveIdentifiersFromProperty(LogGroupDeclarationCheck.java:79)
        at java.base/java.util.Optional.map(Unknown Source)
        at org.sonar.iac.cloudformation.checks.LogGroupDeclarationCheck.getReferenceIdentifiers(LogGroupDeclarationCheck.java:70)
```