### PR TITLE
Use release workflow for closed source projects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,73 +5,41 @@ on:
     types:
       - published
 
+env:
+  PYTHONUNBUFFERED: 1
+
 jobs:
   sonar_release:
     runs-on: ubuntu-latest
     name: Start release process
     steps:
-      - name: Release
-        id: release
+      - name: LT release
+        id: lt_release
+        with:
+          publish_to_binaries: true
+          attach_artifacts_to_github_release: true
+          distribute_target: "SQ-test"
+          run_rules_cov: false
+          slack_channel: test-github-action
         env:
           ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
+          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+          BINTRAY_TOKEN: ${{ secrets.BINTRAY_TOKEN }}
           BURGRX_USER: ${{ secrets.BURGRX_USER }}
           BURGRX_PASSWORD: ${{ secrets.BURGRX_PASSWORD }}
+          CENTRAL_USER: ${{ secrets.CENTRAL_USER }}
+          CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
           CIRRUS_TOKEN: ${{ secrets.CIRRUS_TOKEN }}
           PATH_PREFIX: ${{ secrets.BINARIES_PATH_PREFIX }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           RELEASE_SSH_USER: ${{ secrets.RELEASE_SSH_USER }}
           RELEASE_SSH_KEY: ${{ secrets.RELEASE_SSH_KEY }}
           SLACK_API_TOKEN: ${{secrets.SLACK_API_TOKEN }}
-        uses: SonarSource/gh-action_release/main@v3
-        with:
-          publish_to_binaries: true
-          attach_artifacts_to_github_release: true
-          run_rules_cov: true
-          slack_channel: team-lang-iac
-      - name: Release action results
+        # Put your action repo here
+        uses: SonarSource/gh-action_release/main@v3backup
+
+      - name: Check outputs
         if: always()
         run: |
           echo "${{ steps.lt_release.outputs.releasability }}"
           echo "${{ steps.lt_release.outputs.release }}"
-
-  maven-central-sync:
-    runs-on: ubuntu-latest
-    needs:
-      - sonar_release
-    steps:
-      - name: Setup JFrog CLI
-        uses: jfrog/setup-jfrog-cli@v1
-      - name: JFrog config
-        run: jfrog rt config repox --url https://repox.jfrog.io/artifactory/ --apikey $ARTIFACTORY_API_KEY --basic-auth-only
-        env:
-          ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
-      - name: Get the version
-        id: get_version
-        run: |
-          IFS=. read major minor patch build <<< "${{ github.event.release.tag_name }}"
-          echo ::set-output name=build::"${build}"
-      - name: Create local repository directory
-        id: local_repo
-        run: echo ::set-output name=dir::"$(mktemp -d repo.XXXXXXXX)"
-      - name: Download Artifacts
-        uses: SonarSource/gh-action_release/download-build@v3
-        with:
-          build-number: ${{ steps.get_version.outputs.build }}
-          local-repo-dir: ${{ steps.local_repo.outputs.dir }}
-      - name: Maven Central Sync
-        id: maven-central-sync
-        continue-on-error: true
-        uses: SonarSource/gh-action_release/maven-central-sync@v3
-        with:
-          local-repo-dir: ${{ steps.local_repo.outputs.dir }}
-        env:
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-      - name: Notify on failure
-        if: ${{ failure() || steps.maven-central-sync.outcome == 'failure' }}
-        uses: 8398a7/action-slack@v3
-        with:
-          status: failure
-          fields: repo,author,eventName
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_BUILD_WEBHOOK }}


### PR DESCRIPTION
Following the guide on this XTranet page, we have to use another workflow for GitHub releases when it's a closed source project.
https://xtranet-sonarsource.atlassian.net/wiki/spaces/DEV/pages/776802/Release+Procedures see `Releasing with GitHub Action/Setting up Release Action in GitHub`