### PR TITLE
Use correct artifact name for cirrus pipeline

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -113,7 +113,7 @@ promote_task:
     GCF_ACCESS_TOKEN: ENCRYPTED[!1fb91961a5c01e06e38834e55755231d649dc62eca354593105af9f9d643d701ae4539ab6a8021278b8d9348ae2ce8be!]
     PROMOTE_URL: ENCRYPTED[!e22ed2e34a8f7a1aea5cff653585429bbd3d5151e7201022140218f9c5d620069ec2388f14f83971e3fd726215bc0f5e!]
     #artifacts that will have downloadable links in burgr
-    ARTIFACTS: org.sonarsource.iac:iac-terraform-plugin:jar
+    ARTIFACTS: org.sonarsource.iac:sonar-iac-plugin:jar
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
   script: cirrus_promote_maven

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,8 @@
     <version.mockito>3.9.0</version.mockito>
     <version.snakeyaml>2.3</version.snakeyaml>
     <gitRepositoryName>sonar-iac</gitRepositoryName>
+    <!-- Release: enable publication to Bintray -->
+    <artifactsToPublish>${project.groupId}:sonar-iac-plugin:jar</artifactsToPublish>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
We missed updating the cirrus pipeline after moving to a single plugin structure.