### PR TITLE
HOTFIX 1.9.2: SONARIAC-435 Do not raise parser errors on Helm syntax template directives

### DIFF
--- a/iac-common/pom.xml
+++ b/iac-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.iac</groupId>
     <artifactId>iac</artifactId>
-    <version>1.9.1-SNAPSHOT</version>
+    <version>1.9.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-iac-common</artifactId>

--- a/iac-common/pom.xml
+++ b/iac-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.sonarsource.iac</groupId>
     <artifactId>iac</artifactId>
-    <version>1.9-SNAPSHOT</version>
+    <version>1.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-iac-common</artifactId>

--- a/iac-extensions/cloudformation/pom.xml
+++ b/iac-extensions/cloudformation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.iac</groupId>
     <artifactId>iac-extensions</artifactId>
-    <version>1.9.1-SNAPSHOT</version>
+    <version>1.9.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-iac-cloudformation</artifactId>

--- a/iac-extensions/cloudformation/pom.xml
+++ b/iac-extensions/cloudformation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.iac</groupId>
     <artifactId>iac-extensions</artifactId>
-    <version>1.9-SNAPSHOT</version>
+    <version>1.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-iac-cloudformation</artifactId>

--- a/iac-extensions/kubernetes/pom.xml
+++ b/iac-extensions/kubernetes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>iac-extensions</artifactId>
     <groupId>org.sonarsource.iac</groupId>
-    <version>1.9-SNAPSHOT</version>
+    <version>1.9.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/iac-extensions/kubernetes/pom.xml
+++ b/iac-extensions/kubernetes/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>iac-extensions</artifactId>
     <groupId>org.sonarsource.iac</groupId>
-    <version>1.9.1-SNAPSHOT</version>
+    <version>1.9.2-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/plugin/KubernetesSensor.java
+++ b/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/plugin/KubernetesSensor.java
@@ -22,6 +22,7 @@ package org.sonar.iac.kubernetes.plugin;
 import java.io.IOException;
 import java.util.Scanner;
 import java.util.Set;
+import java.util.regex.Pattern;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.batch.fs.FilePredicate;
 import org.sonar.api.batch.fs.InputFile;
@@ -35,6 +36,13 @@ import org.sonar.iac.common.yaml.YamlSensor;
 import org.sonar.iac.kubernetes.checks.KubernetesCheckList;
 
 public class KubernetesSensor extends YamlSensor {
+
+  private static final String DIRECTIVE_IN_COMMENT = "#.*\\{\\{";
+  private static final String DIRECTIVE_IN_SINGLE_QUOTE = "'[^']*\\{\\{[^']*'";
+  private static final String DIRECTIVE_IN_DOUBLE_QUOTE = "\"[^\"]*\\{\\{[^\"]*\"";
+  private static final String CODEFRESH_VARIABLES = "\\{\\{[\\w\\s]+}}";
+  private static final Pattern HELM_DIRECTIVE_IN_COMMENT_OR_STRING = Pattern.compile("("+
+    String.join("|", DIRECTIVE_IN_COMMENT, DIRECTIVE_IN_SINGLE_QUOTE, DIRECTIVE_IN_DOUBLE_QUOTE, CODEFRESH_VARIABLES) + ")");
 
   public KubernetesSensor(SonarRuntime sonarRuntime, FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory,
                              NoSonarFilter noSonarFilter, KubernetesLanguage language) {
@@ -70,17 +78,22 @@ public class KubernetesSensor extends YamlSensor {
     private static boolean hasKubernetesObjectStructure(InputFile inputFile) {
       int identifierCount = 0;
       try (Scanner scanner = new Scanner(inputFile.inputStream(), inputFile.charset().name())) {
+        boolean atLeastOneCompleteObject = false;
         while (scanner.hasNextLine()) {
           String line = scanner.nextLine();
           if (IDENTIFIER.stream().anyMatch(line::startsWith)) {
             identifierCount++;
           } else if (FILE_SEPERATOR.equals(line)) {
             identifierCount = 0;
+          } else if (line.contains("{{") && !HELM_DIRECTIVE_IN_COMMENT_OR_STRING.matcher(line).find()) {
+            // SONARIAC-435: Do not parse Helm files with template directives
+            return false;
           }
           if (identifierCount == 4) {
-            return true;
+            atLeastOneCompleteObject = true;
           }
         }
+        return atLeastOneCompleteObject;
       } catch (IOException e) {
         LOG.error(String.format("Unable to read file: %s.", inputFile.uri()));
         LOG.error(e.getMessage());

--- a/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/plugin/KubernetesSensor.java
+++ b/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/plugin/KubernetesSensor.java
@@ -36,7 +36,7 @@ import org.sonar.iac.kubernetes.checks.KubernetesCheckList;
 
 public class KubernetesSensor extends YamlSensor {
 
-  protected KubernetesSensor(SonarRuntime sonarRuntime, FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory,
+  public KubernetesSensor(SonarRuntime sonarRuntime, FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory,
                              NoSonarFilter noSonarFilter, KubernetesLanguage language) {
     super(sonarRuntime, fileLinesContextFactory, checkFactory, noSonarFilter, language, KubernetesCheckList.checks());
   }

--- a/iac-extensions/kubernetes/src/test/java/org/sonar/iac/kubernetes/plugin/KubernetesSensorTest.java
+++ b/iac-extensions/kubernetes/src/test/java/org/sonar/iac/kubernetes/plugin/KubernetesSensorTest.java
@@ -71,6 +71,36 @@ class KubernetesSensorTest extends AbstractSensorTest {
   }
 
   @Test
+  void yaml_file_with_helm_template_directives_should_not_be_parsed() {
+    analyse(sensor(), inputFile(K8_IDENTIFIERS + "{{ .Values.count }}"));
+    asserNotSourceFileIsParsed();
+  }
+
+  @Test
+  void yaml_file_with_helm_template_directives_alike_single_quoted_strings_should_be_parsed() {
+    analyse(sensor(), inputFile(K8_IDENTIFIERS + "'{{ .Values.count }}'"));
+    assertOneSourceFileIsParsed();
+  }
+
+  @Test
+  void yaml_file_with_helm_template_directives_alike_double_quoted_strings_should_be_parsed() {
+    analyse(sensor(), inputFile(K8_IDENTIFIERS + "\"{{ .Values.count }}\""));
+    assertOneSourceFileIsParsed();
+  }
+
+  @Test
+  void yaml_file_with_helm_template_directives_alike_comments_should_be_parsed() {
+    analyse(sensor(), inputFile(K8_IDENTIFIERS + "# {{ .Values.count }}"));
+    assertOneSourceFileIsParsed();
+  }
+
+  @Test
+  void yaml_file_with_codefresh_variable_should_be_parsed() {
+    analyse(sensor(), inputFile(K8_IDENTIFIERS + "custom-label: {{MY_CUSTOM_LABEL}}"));
+    assertOneSourceFileIsParsed();
+  }
+
+  @Test
   void yaml_file_with_invalid_syntax_should_not_raise_parsing_if_rule_is_deactivated() {
     analyse(sensor(checkFactory()), inputFileWithIdentifiers("a: b: c"));
 

--- a/iac-extensions/pom.xml
+++ b/iac-extensions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.iac</groupId>
     <artifactId>iac</artifactId>
-    <version>1.9.1-SNAPSHOT</version>
+    <version>1.9.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>iac-extensions</artifactId>

--- a/iac-extensions/pom.xml
+++ b/iac-extensions/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.iac</groupId>
     <artifactId>iac</artifactId>
-    <version>1.9-SNAPSHOT</version>
+    <version>1.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>iac-extensions</artifactId>

--- a/iac-extensions/terraform/pom.xml
+++ b/iac-extensions/terraform/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.iac</groupId>
     <artifactId>iac-extensions</artifactId>
-    <version>1.9.1-SNAPSHOT</version>
+    <version>1.9.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-iac-terraform</artifactId>

--- a/iac-extensions/terraform/pom.xml
+++ b/iac-extensions/terraform/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.iac</groupId>
     <artifactId>iac-extensions</artifactId>
-    <version>1.9-SNAPSHOT</version>
+    <version>1.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-iac-terraform</artifactId>

--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>iac-its</artifactId>
     <groupId>org.sonarsource.iac</groupId>
-    <version>1.9-SNAPSHOT</version>
+    <version>1.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>iac-its-plugin</artifactId>

--- a/its/plugin/pom.xml
+++ b/its/plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>iac-its</artifactId>
     <groupId>org.sonarsource.iac</groupId>
-    <version>1.9.1-SNAPSHOT</version>
+    <version>1.9.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>iac-its-plugin</artifactId>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>iac</artifactId>
     <groupId>org.sonarsource.iac</groupId>
-    <version>1.9-SNAPSHOT</version>
+    <version>1.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>iac-its</artifactId>

--- a/its/pom.xml
+++ b/its/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>iac</artifactId>
     <groupId>org.sonarsource.iac</groupId>
-    <version>1.9.1-SNAPSHOT</version>
+    <version>1.9.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>iac-its</artifactId>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>iac-its</artifactId>
     <groupId>org.sonarsource.iac</groupId>
-    <version>1.9.1-SNAPSHOT</version>
+    <version>1.9.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>iac-its-ruling</artifactId>

--- a/its/ruling/pom.xml
+++ b/its/ruling/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>iac-its</artifactId>
     <groupId>org.sonarsource.iac</groupId>
-    <version>1.9-SNAPSHOT</version>
+    <version>1.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>iac-its-ruling</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.sonarsource.iac</groupId>
   <artifactId>iac</artifactId>
-  <version>1.9-SNAPSHOT</version>
+  <version>1.9.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>SonarSource IaC Analyzer</name>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.sonarsource.iac</groupId>
   <artifactId>iac</artifactId>
-  <version>1.9.1-SNAPSHOT</version>
+  <version>1.9.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>SonarSource IaC Analyzer</name>

--- a/sonar-iac-plugin/pom.xml
+++ b/sonar-iac-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.iac</groupId>
     <artifactId>iac</artifactId>
-    <version>1.9-SNAPSHOT</version>
+    <version>1.9.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-iac-plugin</artifactId>

--- a/sonar-iac-plugin/pom.xml
+++ b/sonar-iac-plugin/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.iac</groupId>
     <artifactId>iac</artifactId>
-    <version>1.9.1-SNAPSHOT</version>
+    <version>1.9.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>sonar-iac-plugin</artifactId>


### PR DESCRIPTION
DO NOT MERGE ON MASTER
Please take into account, that the first 2 commits are already released. The release will be done from this branch and only a cherry-pick of the fix will be on master.