### PR TITLE
SONARIAC-484 Support port range for instruction EXPOSE

### DIFF
--- a/iac-extensions/docker/src/main/java/org/sonar/iac/docker/parser/TreeFactory.java
+++ b/iac-extensions/docker/src/main/java/org/sonar/iac/docker/parser/TreeFactory.java
@@ -115,11 +115,15 @@ public class TreeFactory {
   }
 
   public PortTree port(SyntaxToken portToken, SyntaxToken separatorToken, Optional<SyntaxToken> protocolToken) {
-    return new PortTreeImpl(portToken, separatorToken, protocolToken.orNull());
+    return new PortTreeImpl(portToken, portToken, separatorToken, protocolToken.orNull());
+  }
+
+  public PortTree port(SyntaxToken portMin, SyntaxToken separatorToken, SyntaxToken portMax) {
+    return new PortTreeImpl(portMin, portMax, separatorToken, null);
   }
 
   public PortTree port(SyntaxToken portToken) {
-    return new PortTreeImpl(portToken, null, null);
+    return new PortTreeImpl(portToken, portToken, null, null);
   }
 
   public LabelTree label(SyntaxToken token, List<KeyValuePairTree> keyValuePairs) {

--- a/iac-extensions/docker/src/main/java/org/sonar/iac/docker/parser/grammar/DockerGrammar.java
+++ b/iac-extensions/docker/src/main/java/org/sonar/iac/docker/parser/grammar/DockerGrammar.java
@@ -53,7 +53,6 @@ import static org.sonar.iac.docker.parser.grammar.DockerLexicalGrammar.IMAGE_TAG
 import static org.sonar.iac.docker.parser.grammar.DockerLexicalGrammar.SPACING;
 import static org.sonar.iac.docker.parser.grammar.DockerLexicalGrammar.STRING_LITERAL;
 import static org.sonar.iac.docker.parser.grammar.DockerLexicalGrammar.STRING_LITERAL_WITH_QUOTES;
-import static org.sonar.iac.docker.parser.grammar.DockerLexicalGrammar.STRING_LITERAL_WITHOUT_SPACE;
 import static org.sonar.iac.docker.parser.grammar.DockerLexicalGrammar.STRING_UNTIL_EOL;
 
 @SuppressWarnings("java:S100")
@@ -196,7 +195,8 @@ public class DockerGrammar {
   public PortTree PORT() {
     return b.<PortTree>nonterminal(DockerLexicalGrammar.PORT).is(
       b.firstOf(
-        f.port(b.token(DockerLexicalGrammar.NUMERIC_LITERAL), b.token(DockerLexicalGrammar.SEPARATOR_PORT), b.optional(b.token(STRING_LITERAL_WITHOUT_SPACE))),
+        f.port(b.token(DockerLexicalGrammar.EXPOSE_PORT), b.token(DockerLexicalGrammar.EXPOSE_SEPARATOR_PROTOCOL), b.optional(b.token(DockerLexicalGrammar.EXPOSE_PROTOCOL))),
+        f.port(b.token(DockerLexicalGrammar.EXPOSE_PORT), b.token(DockerLexicalGrammar.EXPOSE_SEPARATOR_PORT), b.token(DockerLexicalGrammar.EXPOSE_PORT)),
         f.port(b.token(DockerLexicalGrammar.STRING_LITERAL))
       )
     );

--- a/iac-extensions/docker/src/main/java/org/sonar/iac/docker/parser/grammar/DockerLexicalConstant.java
+++ b/iac-extensions/docker/src/main/java/org/sonar/iac/docker/parser/grammar/DockerLexicalConstant.java
@@ -30,8 +30,6 @@ public class DockerLexicalConstant {
   public static final String STRING_LITERAL_WITH_QUOTES = "\"(?:[^\"\\\\]*+(?:\\\\[\\s\\S])?+)*+\"";
   public static final String STRING_LITERAL_WITHOUT_QUOTES = "[^\\s=]+";
   public static final String STRING_LITERAL = "(?:" + STRING_LITERAL_WITH_QUOTES + ")|(?:" + STRING_LITERAL_WITHOUT_QUOTES + ")";
-  public static final String NUMERIC_LITERAL = "[0-9]+";
-  public static final String SEPARATOR_PORT = "/";
   public static final String STRING_UNTIL_EOL = ".+";
   public static final String EQUALS_OPERATOR = "=";
 

--- a/iac-extensions/docker/src/main/java/org/sonar/iac/docker/parser/grammar/DockerLexicalGrammar.java
+++ b/iac-extensions/docker/src/main/java/org/sonar/iac/docker/parser/grammar/DockerLexicalGrammar.java
@@ -35,11 +35,8 @@ public enum DockerLexicalGrammar implements GrammarRuleKey {
    * Lexical
    */
   STRING_LITERAL,
-  STRING_LITERAL_WITHOUT_SPACE,
   STRING_UNTIL_EOL,
   STRING_LITERAL_WITH_QUOTES,
-  NUMERIC_LITERAL,
-  SEPARATOR_PORT,
   EQUALS_OPERATOR,
   EOF,
 
@@ -94,7 +91,13 @@ public enum DockerLexicalGrammar implements GrammarRuleKey {
   USER_VARIABLE,
   USER_NAME,
   USER_SEPARATOR,
-  USER_GROUP;
+  USER_GROUP,
+
+  EXPOSE_PORT,
+  EXPOSE_SEPARATOR_PORT,
+  EXPOSE_SEPARATOR_PROTOCOL,
+  EXPOSE_PROTOCOL
+  ;
 
   public static LexerlessGrammarBuilder createGrammarBuilder() {
     LexerlessGrammarBuilder b = LexerlessGrammarBuilder.create();
@@ -123,13 +126,15 @@ public enum DockerLexicalGrammar implements GrammarRuleKey {
     b.rule(EOF).is(b.token(GenericTokenType.EOF, b.endOfInput())).skip();
 
     b.rule(STRING_LITERAL).is(SPACING, b.regexp(DockerLexicalConstant.STRING_LITERAL));
-    b.rule(STRING_LITERAL_WITHOUT_SPACE).is(b.regexp(DockerLexicalConstant.STRING_LITERAL));
     b.rule(STRING_UNTIL_EOL).is(SPACING, b.regexp(DockerLexicalConstant.STRING_UNTIL_EOL));
     b.rule(STRING_LITERAL_WITH_QUOTES).is(SPACING, b.regexp(DockerLexicalConstant.STRING_LITERAL_WITH_QUOTES));
 
-    b.rule(NUMERIC_LITERAL).is(SPACING, b.regexp(DockerLexicalConstant.NUMERIC_LITERAL));
-    b.rule(SEPARATOR_PORT).is(b.regexp(DockerLexicalConstant.SEPARATOR_PORT));
     b.rule(EQUALS_OPERATOR).is(b.regexp(DockerLexicalConstant.EQUALS_OPERATOR));
+
+    b.rule(EXPOSE_PORT).is(SPACING, b.regexp("[0-9]+"));
+    b.rule(EXPOSE_SEPARATOR_PORT).is(b.regexp("-"));
+    b.rule(EXPOSE_SEPARATOR_PROTOCOL).is(b.regexp("/"));
+    b.rule(EXPOSE_PROTOCOL).is(b.regexp("[a-zA-Z]+"));
 
     b.rule(IMAGE_NAME).is(SPACING, b.regexp("[^@:\\s\\$-][^@:\\s\\$]+"));
     b.rule(IMAGE_TAG).is(b.regexp(":[^@\\s\\$]+"));

--- a/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/api/PortTree.java
+++ b/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/api/PortTree.java
@@ -19,8 +19,11 @@
  */
 package org.sonar.iac.docker.tree.api;
 
+import javax.annotation.CheckForNull;
+
 public interface PortTree extends DockerTree {
   SyntaxToken portMin();
   SyntaxToken portMax();
+  @CheckForNull
   SyntaxToken protocol();
 }

--- a/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/api/PortTree.java
+++ b/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/api/PortTree.java
@@ -20,7 +20,7 @@
 package org.sonar.iac.docker.tree.api;
 
 public interface PortTree extends DockerTree {
-  SyntaxToken port();
-  SyntaxToken separator();
+  SyntaxToken portMin();
+  SyntaxToken portMax();
   SyntaxToken protocol();
 }

--- a/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/impl/PortTreeImpl.java
+++ b/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/impl/PortTreeImpl.java
@@ -21,6 +21,7 @@ package org.sonar.iac.docker.tree.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.iac.common.api.tree.Tree;
 import org.sonar.iac.docker.tree.api.PortTree;
@@ -75,6 +76,7 @@ public class PortTreeImpl extends DockerTreeImpl implements PortTree {
   }
 
   @Override
+  @CheckForNull
   public SyntaxToken protocol() {
     return protocol;
   }

--- a/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/impl/PortTreeImpl.java
+++ b/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/impl/PortTreeImpl.java
@@ -27,12 +27,14 @@ import org.sonar.iac.docker.tree.api.PortTree;
 import org.sonar.iac.docker.tree.api.SyntaxToken;
 
 public class PortTreeImpl extends DockerTreeImpl implements PortTree {
-  private final SyntaxToken port;
+  private final SyntaxToken portMin;
+  private final SyntaxToken portMax;
   private final SyntaxToken separator;
   private final SyntaxToken protocol;
 
-  public PortTreeImpl(SyntaxToken port, @Nullable SyntaxToken separator, @Nullable SyntaxToken protocol) {
-    this.port = port;
+  public PortTreeImpl(SyntaxToken portMin, SyntaxToken portMax, @Nullable SyntaxToken separator, @Nullable SyntaxToken protocol) {
+    this.portMin = portMin;
+    this.portMax = portMax;
     this.separator = separator;
     this.protocol = protocol;
   }
@@ -40,12 +42,19 @@ public class PortTreeImpl extends DockerTreeImpl implements PortTree {
   @Override
   public List<Tree> children() {
     List<Tree> children = new ArrayList<>();
-    children.add(this.port);
-    if (this.separator != null) {
+    children.add(this.portMin);
+    // range format : 'portmin-portmax'
+    if (this.portMin != this.portMax) {
       children.add(this.separator);
-    }
-    if (this.protocol != null) {
-      children.add(this.protocol);
+      children.add(this.portMax);
+    } else {
+      // one port format : 'port' or 'port/protocol'
+      if (this.separator != null) {
+        children.add(this.separator);
+      }
+      if (this.protocol != null) {
+        children.add(this.protocol);
+      }
     }
     return children;
   }
@@ -56,13 +65,13 @@ public class PortTreeImpl extends DockerTreeImpl implements PortTree {
   }
 
   @Override
-  public SyntaxToken port() {
-    return port;
+  public SyntaxToken portMin() {
+    return portMin;
   }
 
   @Override
-  public SyntaxToken separator() {
-    return separator;
+  public SyntaxToken portMax() {
+    return portMax;
   }
 
   @Override

--- a/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/ExposeTreeImplTest.java
+++ b/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/ExposeTreeImplTest.java
@@ -35,6 +35,7 @@ class ExposeTreeImplTest {
   void matchingSimple() {
     Assertions.assertThat(DockerLexicalGrammar.EXPOSE)
       .matches("EXPOSE 80")
+      .matches("EXPOSE bob")
       .matches("EXPOSE 80-88")
       .matches("    EXPOSE 80")
       .matches("expose 80")
@@ -46,7 +47,12 @@ class ExposeTreeImplTest {
       .matches("EXPOSE 80 /tcp")
       .matches("EXPOSE \"80/tcp\"")
       .matches("EXPOSE 8\"0/t\"cp")
-      .matches("EXPOSE $myport");
+      .matches("EXPOSE $myport")
+      .matches("EXPOSE80") // TODO : Should not match SONARIAC-489
+      .notMatches("EXPOSE")
+      .notMatches("EXPOSE ")
+      .notMatches("EXPOSEE")
+    ;
   }
 
   @Test
@@ -74,8 +80,11 @@ class ExposeTreeImplTest {
     assertThat(port1.getKind()).isEqualTo(DockerTree.Kind.PORT);
     assertThat(port1.portMin().value()).isEqualTo("80");
     assertThat(port1.portMin()).isEqualTo(port1.portMax());
-    assertThat(((SyntaxToken) port1.children().get(1)).value()).isEqualTo("/");
     assertThat(port1.protocol()).isNull();
+
+    assertThat(port1.children()).hasSize(2);
+    assertThat(port1.children().get(0)).isSameAs(port1.portMin());
+    assertThat(((SyntaxToken) port1.children().get(1)).value()).isEqualTo("/");
   }
 
   @Test
@@ -89,8 +98,12 @@ class ExposeTreeImplTest {
     assertThat(port1.getKind()).isEqualTo(DockerTree.Kind.PORT);
     assertThat(port1.portMin().value()).isEqualTo("80");
     assertThat(port1.portMin()).isEqualTo(port1.portMax());
-    assertThat(((SyntaxToken) port1.children().get(1)).value()).isEqualTo("/");
     assertThat(port1.protocol().value()).isEqualTo("tcp");
+
+    assertThat(port1.children()).hasSize(3);
+    assertThat(port1.children().get(0)).isSameAs(port1.portMin());
+    assertThat(((SyntaxToken) port1.children().get(1)).value()).isEqualTo("/");
+    assertThat(port1.children().get(2)).isSameAs(port1.protocol());
   }
 
   @Test
@@ -104,13 +117,18 @@ class ExposeTreeImplTest {
     assertThat(port1.getKind()).isEqualTo(DockerTree.Kind.PORT);
     assertThat(port1.portMin().value()).isEqualTo("80");
     assertThat(port1.portMin()).isEqualTo(port1.portMax());
-    assertThat(((SyntaxToken) port1.children().get(1)).value()).isEqualTo("/");
     assertThat(port1.protocol().value()).isEqualTo("tcp");
+    assertThat(port1.children()).hasSize(3);
+    assertThat(port1.children().get(0)).isSameAs(port1.portMin());
+    assertThat(((SyntaxToken) port1.children().get(1)).value()).isEqualTo("/");
+    assertThat(port1.children().get(2)).isSameAs(port1.protocol());
 
     PortTree port2 = tree.ports().get(1);
     assertThat(port2.getKind()).isEqualTo(DockerTree.Kind.PORT);
     assertThat(port2.portMin().value()).isEqualTo("443");
     assertThat(port2.protocol()).isNull();
+    assertThat(port2.children()).hasSize(1);
+    assertThat(port2.children().get(0)).isSameAs(port2.portMin());
   }
 
   @Test
@@ -125,6 +143,8 @@ class ExposeTreeImplTest {
     assertThat(port1.portMin().value()).isEqualTo("${my_port}");
     assertThat(port1.portMin()).isEqualTo(port1.portMax());
     assertThat(port1.protocol()).isNull();
+    assertThat(port1.children()).hasSize(1);
+    assertThat(port1.children().get(0)).isSameAs(port1.portMin());
   }
 
   @Test
@@ -140,6 +160,8 @@ class ExposeTreeImplTest {
     assertThat(port1.portMin().value()).isEqualTo("8\"0/t\"cp");
     assertThat(port1.portMin()).isEqualTo(port1.portMax());
     assertThat(port1.protocol()).isNull();
+    assertThat(port1.children()).hasSize(1);
+    assertThat(port1.children().get(0)).isSameAs(port1.portMin());
   }
 
   @Test
@@ -153,7 +175,11 @@ class ExposeTreeImplTest {
     assertThat(port1.getKind()).isEqualTo(DockerTree.Kind.PORT);
     assertThat(port1.portMin().value()).isEqualTo("80");
     assertThat(port1.portMax().value()).isEqualTo("89");
-    assertThat(((SyntaxToken) port1.children().get(1)).value()).isEqualTo("-");
     assertThat(port1.protocol()).isNull();
+
+    assertThat(port1.children()).hasSize(3);
+    assertThat(port1.children().get(0)).isSameAs(port1.portMin());
+    assertThat(((SyntaxToken) port1.children().get(1)).value()).isEqualTo("-");
+    assertThat(port1.children().get(2)).isSameAs(port1.portMax());
   }
 }

--- a/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/ExposeTreeImplTest.java
+++ b/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/ExposeTreeImplTest.java
@@ -25,6 +25,7 @@ import org.sonar.iac.docker.parser.utils.Assertions;
 import org.sonar.iac.docker.tree.api.DockerTree;
 import org.sonar.iac.docker.tree.api.ExposeTree;
 import org.sonar.iac.docker.tree.api.PortTree;
+import org.sonar.iac.docker.tree.api.SyntaxToken;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.sonar.iac.docker.tree.impl.DockerTestUtils.parse;
@@ -57,8 +58,8 @@ class ExposeTreeImplTest {
 
     PortTree port1 = tree.ports().get(0);
     assertThat(port1.getKind()).isEqualTo(DockerTree.Kind.PORT);
-    assertThat(port1.port().value()).isEqualTo("80");
-    assertThat(port1.separator()).isNull();
+    assertThat(port1.portMin().value()).isEqualTo("80");
+    assertThat(port1.portMin()).isEqualTo(port1.portMax());
     assertThat(port1.protocol()).isNull();
   }
 
@@ -71,8 +72,9 @@ class ExposeTreeImplTest {
 
     PortTree port1 = tree.ports().get(0);
     assertThat(port1.getKind()).isEqualTo(DockerTree.Kind.PORT);
-    assertThat(port1.port().value()).isEqualTo("80");
-    assertThat(port1.separator().value()).isEqualTo("/");
+    assertThat(port1.portMin().value()).isEqualTo("80");
+    assertThat(port1.portMin()).isEqualTo(port1.portMax());
+    assertThat(((SyntaxToken) port1.children().get(1)).value()).isEqualTo("/");
     assertThat(port1.protocol()).isNull();
   }
 
@@ -85,8 +87,9 @@ class ExposeTreeImplTest {
 
     PortTree port1 = tree.ports().get(0);
     assertThat(port1.getKind()).isEqualTo(DockerTree.Kind.PORT);
-    assertThat(port1.port().value()).isEqualTo("80");
-    assertThat(port1.separator().value()).isEqualTo("/");
+    assertThat(port1.portMin().value()).isEqualTo("80");
+    assertThat(port1.portMin()).isEqualTo(port1.portMax());
+    assertThat(((SyntaxToken) port1.children().get(1)).value()).isEqualTo("/");
     assertThat(port1.protocol().value()).isEqualTo("tcp");
   }
 
@@ -99,14 +102,14 @@ class ExposeTreeImplTest {
 
     PortTree port1 = tree.ports().get(0);
     assertThat(port1.getKind()).isEqualTo(DockerTree.Kind.PORT);
-    assertThat(port1.port().value()).isEqualTo("80");
-    assertThat(port1.separator().value()).isEqualTo("/");
+    assertThat(port1.portMin().value()).isEqualTo("80");
+    assertThat(port1.portMin()).isEqualTo(port1.portMax());
+    assertThat(((SyntaxToken) port1.children().get(1)).value()).isEqualTo("/");
     assertThat(port1.protocol().value()).isEqualTo("tcp");
 
     PortTree port2 = tree.ports().get(1);
     assertThat(port2.getKind()).isEqualTo(DockerTree.Kind.PORT);
-    assertThat(port2.port().value()).isEqualTo("443");
-    assertThat(port2.separator()).isNull();
+    assertThat(port2.portMin().value()).isEqualTo("443");
     assertThat(port2.protocol()).isNull();
   }
 
@@ -119,8 +122,8 @@ class ExposeTreeImplTest {
 
     PortTree port1 = tree.ports().get(0);
     assertThat(port1.getKind()).isEqualTo(DockerTree.Kind.PORT);
-    assertThat(port1.port().value()).isEqualTo("${my_port}");
-    assertThat(port1.separator()).isNull();
+    assertThat(port1.portMin().value()).isEqualTo("${my_port}");
+    assertThat(port1.portMin()).isEqualTo(port1.portMax());
     assertThat(port1.protocol()).isNull();
   }
 
@@ -134,8 +137,8 @@ class ExposeTreeImplTest {
 
     PortTree port1 = tree.ports().get(0);
     assertThat(port1.getKind()).isEqualTo(DockerTree.Kind.PORT);
-    assertThat(port1.port().value()).isEqualTo("8\"0/t\"cp");
-    assertThat(port1.separator()).isNull();
+    assertThat(port1.portMin().value()).isEqualTo("8\"0/t\"cp");
+    assertThat(port1.portMin()).isEqualTo(port1.portMax());
     assertThat(port1.protocol()).isNull();
   }
 
@@ -148,8 +151,9 @@ class ExposeTreeImplTest {
 
     PortTree port1 = tree.ports().get(0);
     assertThat(port1.getKind()).isEqualTo(DockerTree.Kind.PORT);
-    assertThat(port1.port().value()).isEqualTo("80-89");
-    assertThat(port1.separator()).isNull();
+    assertThat(port1.portMin().value()).isEqualTo("80");
+    assertThat(port1.portMax().value()).isEqualTo("89");
+    assertThat(((SyntaxToken) port1.children().get(1)).value()).isEqualTo("-");
     assertThat(port1.protocol()).isNull();
   }
 }


### PR DESCRIPTION
I choose the simple approach of adding another field to handle port + replacing the existing one : `port` -> `portMin` and `portMax`.
In case there is only one port provided -> `portMin == portMax`
Another solution would be to have this in another class `PortRangeTreeImpl`, open to challenge !
I took also the opportunity to fix the related grammar.