### PR TITLE
SONARIAC-491 Docker: parse comment

### DIFF
--- a/iac-extensions/docker/src/main/java/org/sonar/iac/docker/parser/TreeFactory.java
+++ b/iac-extensions/docker/src/main/java/org/sonar/iac/docker/parser/TreeFactory.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.sonar.iac.docker.tree.api.AliasTree;
 import org.sonar.iac.docker.tree.api.ArgTree;
 import org.sonar.iac.docker.tree.api.CmdTree;
+import org.sonar.iac.docker.tree.api.CommentTree;
 import org.sonar.iac.docker.tree.api.EntrypointTree;
 import org.sonar.iac.docker.tree.api.CopyTree;
 import org.sonar.iac.docker.tree.api.EnvTree;
@@ -57,6 +58,7 @@ import org.sonar.iac.docker.tree.api.WorkdirTree;
 import org.sonar.iac.docker.tree.impl.AliasTreeImpl;
 import org.sonar.iac.docker.tree.impl.ArgTreeImpl;
 import org.sonar.iac.docker.tree.impl.CmdTreeImpl;
+import org.sonar.iac.docker.tree.impl.CommentTreeImpl;
 import org.sonar.iac.docker.tree.impl.EntrypointTreeImpl;
 import org.sonar.iac.docker.tree.impl.CopyTreeImpl;
 import org.sonar.iac.docker.tree.impl.EnvTreeImpl;
@@ -215,6 +217,10 @@ public class TreeFactory {
 
   public HealthCheckTree healthcheck(SyntaxToken healthcheck, Optional<List<ParamTree>> options, InstructionTree instruction) {
     return new HealthCheckTreeImpl(healthcheck, options.or(Collections.emptyList()), instruction);
+  }
+
+  public CommentTree comment(SyntaxToken keyword, SyntaxToken comment) {
+    return new CommentTreeImpl(keyword, comment);
   }
 
   public NoneTree none(SyntaxToken none) {

--- a/iac-extensions/docker/src/main/java/org/sonar/iac/docker/parser/grammar/DockerGrammar.java
+++ b/iac-extensions/docker/src/main/java/org/sonar/iac/docker/parser/grammar/DockerGrammar.java
@@ -27,6 +27,7 @@ import org.sonar.iac.docker.tree.api.AddTree;
 import org.sonar.iac.docker.tree.api.AliasTree;
 import org.sonar.iac.docker.tree.api.ArgTree;
 import org.sonar.iac.docker.tree.api.CmdTree;
+import org.sonar.iac.docker.tree.api.CommentTree;
 import org.sonar.iac.docker.tree.api.EntrypointTree;
 import org.sonar.iac.docker.tree.api.CopyTree;
 import org.sonar.iac.docker.tree.api.EnvTree;
@@ -102,7 +103,8 @@ public class DockerGrammar {
           USER(),
           VOLUME(),
           SHELL(),
-          HEALTHCHECK()
+          HEALTHCHECK(),
+          COMMENT()
         )
       )
     );
@@ -374,6 +376,15 @@ public class DockerGrammar {
         b.token(DockerKeyword.HEALTHCHECK),
         b.zeroOrMore(PARAM()),
         b.firstOf(NONE(), CMD())
+      )
+    );
+  }
+
+  public CommentTree COMMENT() {
+    return b.<CommentTree>nonterminal(DockerLexicalGrammar.COMMENT).is(
+      f.comment(
+        b.token(DockerLexicalGrammar.COMMENT_TOKEN),
+        b.token(DockerLexicalGrammar.COMMENT_CONTENT)
       )
     );
   }

--- a/iac-extensions/docker/src/main/java/org/sonar/iac/docker/parser/grammar/DockerLexicalGrammar.java
+++ b/iac-extensions/docker/src/main/java/org/sonar/iac/docker/parser/grammar/DockerLexicalGrammar.java
@@ -44,6 +44,7 @@ public enum DockerLexicalGrammar implements GrammarRuleKey {
    * SPACING
    */
   SPACING,
+  OPTIONAL_SPACING,
   INSTRUCTION_SPACING,
 
   /**
@@ -67,6 +68,7 @@ public enum DockerLexicalGrammar implements GrammarRuleKey {
   VOLUME,
   SHELL,
   HEALTHCHECK,
+  COMMENT,
   NONE,
 
   /**
@@ -103,7 +105,10 @@ public enum DockerLexicalGrammar implements GrammarRuleKey {
   EXPOSE_PORT,
   EXPOSE_SEPARATOR_PORT,
   EXPOSE_SEPARATOR_PROTOCOL,
-  EXPOSE_PROTOCOL;
+  EXPOSE_PROTOCOL,
+
+  COMMENT_TOKEN,
+  COMMENT_CONTENT;
 
   public static LexerlessGrammarBuilder createGrammarBuilder() {
     LexerlessGrammarBuilder b = LexerlessGrammarBuilder.create();
@@ -136,6 +141,8 @@ public enum DockerLexicalGrammar implements GrammarRuleKey {
         b.skippedTrivia(b.regexp("[" + LexicalConstant.LINE_TERMINATOR + LexicalConstant.WHITESPACE + "]*+")))
     ).skip();
 
+    b.rule(OPTIONAL_SPACING).is(b.skippedTrivia(b.regexp("[" + LexicalConstant.WHITESPACE + "]*+"))).skip();
+
     b.rule(EOF).is(b.token(GenericTokenType.EOF, b.endOfInput())).skip();
 
     b.rule(STRING_LITERAL).is(SPACING, b.regexp(DockerLexicalConstant.STRING_LITERAL));
@@ -163,6 +170,9 @@ public enum DockerLexicalGrammar implements GrammarRuleKey {
     b.rule(USER_NAME).is(SPACING, b.firstOf(USER_STRING, USER_VARIABLE));
     b.rule(USER_SEPARATOR).is(b.regexp(":"));
     b.rule(USER_GROUP).is(b.firstOf(USER_STRING, USER_VARIABLE));
+
+    b.rule(COMMENT_TOKEN).is(OPTIONAL_SPACING, b.regexp("#"));
+    b.rule(COMMENT_CONTENT).is(b.regexp("[^\\n\\r]*"));
   }
 
   private static void keywords(LexerlessGrammarBuilder b) {

--- a/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/api/CommentTree.java
+++ b/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/api/CommentTree.java
@@ -1,0 +1,25 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.iac.docker.tree.api;
+
+public interface CommentTree extends InstructionTree {
+
+  SyntaxToken comment();
+}

--- a/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/api/DockerTree.java
+++ b/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/api/DockerTree.java
@@ -56,6 +56,7 @@ public interface DockerTree extends Tree {
     USER(UserTree.class),
     SHELL(ShellTree.class),
     HEALTHCHECK(HealthCheckTree.class),
+    COMMENT(CommentTree.class),
     NONE(NoneTree.class),
 
     TOKEN(SyntaxToken.class);

--- a/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/impl/CommentTreeImpl.java
+++ b/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/impl/CommentTreeImpl.java
@@ -1,0 +1,50 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.iac.docker.tree.impl;
+
+import java.util.List;
+import org.sonar.iac.common.api.tree.Tree;
+import org.sonar.iac.docker.tree.api.CommentTree;
+import org.sonar.iac.docker.tree.api.SyntaxToken;
+
+public class CommentTreeImpl extends InstructionTreeImpl implements CommentTree {
+
+  private final SyntaxToken comment;
+
+  public CommentTreeImpl(SyntaxToken keyword, SyntaxToken comment) {
+    super(keyword);
+    this.comment = comment;
+  }
+
+  @Override
+  public List<Tree> children() {
+    return List.of(keyword, comment);
+  }
+
+  @Override
+  public SyntaxToken comment() {
+    return comment;
+  }
+
+  @Override
+  public Kind getKind() {
+    return Kind.COMMENT;
+  }
+}

--- a/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/CommentTreeImplTest.java
+++ b/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/CommentTreeImplTest.java
@@ -1,0 +1,76 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.iac.docker.tree.impl;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.iac.docker.parser.grammar.DockerLexicalGrammar;
+import org.sonar.iac.docker.parser.utils.Assertions;
+import org.sonar.iac.docker.tree.api.CommentTree;
+import org.sonar.iac.docker.tree.api.DockerTree;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.iac.common.testing.TextRangeAssert.assertTextRange;
+import static org.sonar.iac.docker.tree.impl.DockerTestUtils.parse;
+
+class CommentTreeImplTest {
+  @Test
+  void shouldParseCmdExecForm() {
+    Assertions.assertThat(DockerLexicalGrammar.COMMENT)
+      .matches("#")
+      .matches("##")
+      .matches("# comment")
+      .matches("    # comment")
+      .matches("#comment")
+      .matches("# comment #")
+      .matches("## comment")
+      .notMatches("CMD # comment")
+      .notMatches("\\# comment")
+      .notMatches("# comment\\\nsomething else")
+      .notMatches("");
+  }
+
+  @Test
+  void commentSimple() {
+    CommentTree tree = parse("# comment", DockerLexicalGrammar.COMMENT);
+    assertThat(tree.getKind()).isEqualTo(DockerTree.Kind.COMMENT);
+    assertThat(tree.keyword().value()).isEqualTo("#");
+    assertTextRange(tree.textRange()).hasRange(1, 0, 1, 9);
+    assertThat(tree.comment().value()).isEqualTo(" comment");
+    assertThat(tree.children()).hasSize(2);
+  }
+
+  @Test
+  void commentSimpleWithSpacesBefore() {
+    CommentTree tree = parse("     # comment", DockerLexicalGrammar.COMMENT);
+    assertThat(tree.getKind()).isEqualTo(DockerTree.Kind.COMMENT);
+    assertThat(tree.keyword().value()).isEqualTo("#");
+    assertTextRange(tree.textRange()).hasRange(1, 5, 1, 14);
+    assertThat(tree.comment().value()).isEqualTo(" comment");
+    assertThat(tree.children()).hasSize(2);
+  }
+
+  @Test
+  void commentEmpty() {
+    CommentTree tree = parse("#", DockerLexicalGrammar.COMMENT);
+    assertTextRange(tree.textRange()).hasRange(1, 0, 1, 1);
+    assertThat(tree.comment().value()).isEmpty();
+    assertThat(tree.children()).hasSize(2);
+  }
+}


### PR DESCRIPTION
I go the easy way by considering comment to be a sort of instruction, it make the grammar simpler. It still does not feel totally right to say a comment is an instruction.
Free to challenge, otherwise I see two other option :
- be more generic by not having CommentTree inherit from InstructionTree but DockerTree (+ adapting the code / FILE)
- add an intermediary interface between InstructionTree and DockerTree (LineCodeTree ? I'm still bad at finding names :D)