### PR TITLE
SONARIAC-595 TransferInstruction should relay on Arguments not on SyntaxTokens

### DIFF
--- a/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/impl/AbstractTransferImpl.java
+++ b/iac-extensions/docker/src/main/java/org/sonar/iac/docker/tree/impl/AbstractTransferImpl.java
@@ -24,10 +24,9 @@ import java.util.List;
 import org.sonar.iac.common.api.tree.Tree;
 import org.sonar.iac.docker.tree.api.Argument;
 import org.sonar.iac.docker.tree.api.ArgumentList;
-import org.sonar.iac.docker.tree.api.TransferInstruction;
 import org.sonar.iac.docker.tree.api.Flag;
 import org.sonar.iac.docker.tree.api.SyntaxToken;
-import org.sonar.iac.docker.utils.ArgumentUtils;
+import org.sonar.iac.docker.tree.api.TransferInstruction;
 
 /**
  * To be used when we want to implement a command that expect one+ src with one dest (supporting both SHELL and EXEC format) with Params.
@@ -51,17 +50,15 @@ public abstract class AbstractTransferImpl extends InstructionImpl implements Tr
   }
 
   @Override
-  public List<SyntaxToken> srcs() {
+  public List<Argument> srcs() {
     List<Argument> args = srcsAndDest.arguments();
-    List<Argument> srcs = args.subList(0, args.size()-1);
-    return ArgumentUtils.argumentsToSyntaxTokens(srcs);
+    return args.subList(0, args.size()-1);
   }
 
   @Override
-  public SyntaxToken dest() {
+  public Argument dest() {
     List<Argument> args = srcsAndDest.arguments();
-    Argument dest = args.get(args.size()-1);
-    return ArgumentUtils.resolve(dest).asSyntaxToken();
+    return args.get(args.size()-1);
   }
 
   @Override

--- a/iac-extensions/docker/src/test/java/org/sonar/iac/docker/TestUtils.java
+++ b/iac-extensions/docker/src/test/java/org/sonar/iac/docker/TestUtils.java
@@ -29,8 +29,8 @@ import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import org.sonar.iac.common.api.tree.Tree;
 import org.sonar.iac.docker.tree.api.Argument;
+import org.sonar.iac.docker.tree.api.ArgumentAssert;
 import org.sonar.iac.docker.tree.api.FromInstruction;
-import org.sonar.iac.docker.utils.ArgumentUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,25 +40,20 @@ public class TestUtils {
     // utils class
   }
 
-  @Nullable
-  public static String argValue(Argument argument) {
-    return ArgumentUtils.resolve(argument).value();
-  }
-
   public static void assertArgumentsValue(List<Argument> args, String... values) {
     assertThat(args).hasSize(values.length);
     for (int i = 0; i < args.size(); i++) {
-      assertThat(argValue(args.get(i))).isEqualTo(values[i]);
+      ArgumentAssert.assertThat(args.get(i)).hasValue(values[i]);
     }
   }
 
   public static void assertFrom(FromInstruction from, String expectedName, @Nullable String expectedFlagName, @Nullable String expectedFlagValue, @Nullable String expectedAlias) {
-    assertThat(argValue(from.image())).isEqualTo(expectedName);
+    ArgumentAssert.assertThat(from.image()).hasValue(expectedName);
     if (expectedFlagName != null) {
       assertThat(from.platform()).isNotNull();
       assertThat(from.platform().name()).isEqualTo(expectedFlagName);
       if (expectedFlagValue != null) {
-        assertThat(argValue(from.platform().value())).isEqualTo(expectedFlagValue);
+        ArgumentAssert.assertThat(from.platform().value()).hasValue(expectedFlagValue);
       } else {
         assertThat(from.platform().value()).isNull();
       }

--- a/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/api/ArgumentAssert.java
+++ b/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/api/ArgumentAssert.java
@@ -36,11 +36,13 @@ public class ArgumentAssert extends DockerTreeAssert<ArgumentAssert, Argument> {
   }
 
   public ArgumentAssert hasValue(String value) {
+    isNotNull();
     resolve().hasValue(value);
     return this;
   }
 
   public ArgumentAssert isUnresolved() {
+    isNotNull();
     resolve().isUnresolved();
     return this;
   }

--- a/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/api/ArgumentAssert.java
+++ b/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/api/ArgumentAssert.java
@@ -19,10 +19,29 @@
  */
 package org.sonar.iac.docker.tree.api;
 
-import java.util.List;
+import org.sonar.iac.docker.utils.ArgumentUtils;
 
-public interface TransferInstruction extends Instruction {
-  List<Flag> options();
-  List<Argument> srcs();
-  Argument dest();
+public class ArgumentAssert extends DockerTreeAssert<ArgumentAssert, Argument> {
+
+  private ArgumentAssert(Argument argument) {
+    super(argument, ArgumentAssert.class);
+  }
+
+  public static ArgumentAssert assertThat(Argument actual) {
+    return new ArgumentAssert(actual);
+  }
+
+  public ArgumentResolutionAssert resolve() {
+    return new ArgumentResolutionAssert(ArgumentUtils.resolve(actual));
+  }
+
+  public ArgumentAssert hasValue(String value) {
+    resolve().hasValue(value);
+    return this;
+  }
+
+  public ArgumentAssert isUnresolved() {
+    resolve().isUnresolved();
+    return this;
+  }
 }

--- a/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/api/ArgumentResolutionAssert.java
+++ b/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/api/ArgumentResolutionAssert.java
@@ -1,0 +1,47 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.iac.docker.tree.api;
+
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+import org.sonar.iac.docker.utils.ArgumentUtils;
+
+public class ArgumentResolutionAssert extends AbstractAssert<ArgumentResolutionAssert, ArgumentUtils.ArgumentResolution> {
+
+  protected ArgumentResolutionAssert(ArgumentUtils.ArgumentResolution argumentResolution) {
+    super(argumentResolution, ArgumentResolutionAssert.class);
+  }
+
+  public ArgumentResolutionAssert hasValue(String value) {
+    isNotNull();
+    Assertions.assertThat(actual.value())
+      .overridingErrorMessage("Expected ArgumentResolution value to be <%s> but was <%s>", value, actual.value())
+      .isEqualTo(value);
+    return this;
+  }
+
+  public ArgumentResolutionAssert isUnresolved() {
+    isNotNull();
+    Assertions.assertThat(actual.value())
+      .overridingErrorMessage("Expected ArgumentResolution to be unresolved but value was <%s>", actual.value())
+      .isNull();
+    return this;
+  }
+}

--- a/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/AddInstructionImplTest.java
+++ b/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/AddInstructionImplTest.java
@@ -24,9 +24,10 @@ import org.junit.jupiter.api.Test;
 import org.sonar.iac.docker.parser.grammar.DockerLexicalGrammar;
 import org.sonar.iac.docker.parser.utils.Assertions;
 import org.sonar.iac.docker.tree.api.AddInstruction;
+import org.sonar.iac.docker.tree.api.Argument;
+import org.sonar.iac.docker.tree.api.ArgumentAssert;
 import org.sonar.iac.docker.tree.api.DockerTree;
 import org.sonar.iac.docker.tree.api.Flag;
-import org.sonar.iac.docker.tree.api.SyntaxToken;
 import org.sonar.iac.docker.utils.ArgumentUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,8 +66,8 @@ class AddInstructionImplTest {
     assertTextRange(tree.textRange()).hasRange(1, 0, 1, 12);
     assertThat(tree.options()).isEmpty();
     assertThat(tree.srcs()).hasSize(1);
-    assertThat(tree.srcs().get(0).value()).isEqualTo("src");
-    assertThat(tree.dest().value()).isEqualTo("dest");
+    ArgumentAssert.assertThat(tree.srcs().get(0)).hasValue("src");
+    ArgumentAssert.assertThat(tree.dest()).hasValue("dest");
   }
 
   @Test
@@ -77,8 +78,8 @@ class AddInstructionImplTest {
     assertTextRange(tree.textRange()).hasRange(1, 0, 1, 13);
     assertThat(tree.options()).isEmpty();
     assertThat(tree.srcs()).hasSize(1);
-    assertThat(tree.srcs().get(0).value()).isEqualTo("src");
-    assertThat(tree.dest()).isNull();
+    ArgumentAssert.assertThat(tree.srcs().get(0)).hasValue("src");
+    ArgumentAssert.assertThat(tree.dest()).isUnresolved();
   }
 
   @Test
@@ -89,8 +90,8 @@ class AddInstructionImplTest {
     assertTextRange(tree.textRange()).hasRange(1, 0, 1, 19);
     assertThat(tree.options()).isEmpty();
     assertThat(tree.srcs()).hasSize(1);
-    assertThat(tree.srcs().get(0).value()).isEqualTo("src");
-    assertThat(tree.dest().value()).isEqualTo("dest");
+    ArgumentAssert.assertThat(tree.srcs().get(0)).hasValue("src");
+    ArgumentAssert.assertThat(tree.dest()).hasValue("dest");
   }
 
   @Test
@@ -100,12 +101,12 @@ class AddInstructionImplTest {
     assertThat(tree.keyword().value()).isEqualTo("ADD");
     assertTextRange(tree.textRange()).hasRange(1, 0, 1, 36);
     assertThat(tree.options()).isEmpty();
-    List<SyntaxToken> srcs = tree.srcs();
+    List<Argument> srcs = tree.srcs();
     assertThat(srcs).hasSize(3);
-    assertThat(srcs.get(0).value()).isEqualTo("src1");
-    assertThat(srcs.get(1).value()).isEqualTo("src2");
-    assertThat(srcs.get(2).value()).isEqualTo("src3");
-    assertThat(tree.dest().value()).isEqualTo("dest");
+    ArgumentAssert.assertThat(tree.srcs().get(0)).hasValue("src1");
+    ArgumentAssert.assertThat(tree.srcs().get(1)).hasValue("src2");
+    ArgumentAssert.assertThat(tree.srcs().get(2)).hasValue("src3");
+    ArgumentAssert.assertThat(tree.dest()).hasValue("dest");
   }
 
   @Test
@@ -115,8 +116,8 @@ class AddInstructionImplTest {
     assertTextRange(tree.textRange()).hasRange(1, 0, 1, 16);
     assertThat(tree.options()).isEmpty();
     assertThat(tree.srcs()).hasSize(1);
-    assertThat(tree.srcs().get(0).value()).isEqualTo("src");
-    assertThat(tree.dest().value()).isEqualTo("dest");
+    ArgumentAssert.assertThat(tree.srcs().get(0)).hasValue("src");
+    ArgumentAssert.assertThat(tree.dest()).hasValue("dest");
   }
 
   @Test
@@ -126,7 +127,7 @@ class AddInstructionImplTest {
     assertTextRange(tree.textRange()).hasRange(1, 0, 1, 8);
     assertThat(tree.options()).isEmpty();
     assertThat(tree.srcs()).isEmpty();
-    assertThat(tree.dest().value()).isEqualTo("dest");
+    ArgumentAssert.assertThat(tree.dest()).hasValue("dest");
   }
 
   @Test
@@ -136,9 +137,9 @@ class AddInstructionImplTest {
     assertTextRange(tree.textRange()).hasRange(1, 0, 1, 18);
     assertThat(tree.options()).isEmpty();
     assertThat(tree.srcs()).hasSize(2);
-    assertThat(tree.srcs().get(0).value()).isEqualTo("src1");
-    assertThat(tree.srcs().get(1).value()).isEqualTo("src2");
-    assertThat(tree.dest().value()).isEqualTo("dest");
+    ArgumentAssert.assertThat(tree.srcs().get(0)).hasValue("src1");
+    ArgumentAssert.assertThat(tree.srcs().get(1)).hasValue("src2");
+    ArgumentAssert.assertThat(tree.dest()).hasValue("dest");
   }
 
   @Test
@@ -153,8 +154,8 @@ class AddInstructionImplTest {
     assertThat(option.name()).isEqualTo("link");
     assertThat(option.value()).isNull();
     assertThat(tree.srcs()).hasSize(1);
-    assertThat(tree.srcs().get(0).value()).isEqualTo("/foo");
-    assertThat(tree.dest().value()).isEqualTo("/bar");
+    ArgumentAssert.assertThat(tree.srcs().get(0)).hasValue("/foo");
+    ArgumentAssert.assertThat(tree.dest()).hasValue("/bar");
   }
 
   @Test
@@ -170,8 +171,9 @@ class AddInstructionImplTest {
     assertThat(ArgumentUtils.resolve(option.value()).value()).isEqualTo("55:mygroup");
 
     assertThat(tree.srcs()).hasSize(1);
-    assertThat(tree.srcs().get(0).value()).isEqualTo("files*");
-    assertThat(tree.dest().value()).isEqualTo("/somedir/");
+
+    ArgumentAssert.assertThat(tree.srcs().get(0)).hasValue("files*");
+    ArgumentAssert.assertThat(tree.dest()).hasValue("/somedir/");
   }
 
   @Test
@@ -192,7 +194,7 @@ class AddInstructionImplTest {
     assertThat(ArgumentUtils.resolve(option2.value()).value()).isEqualTo("value2");
 
     assertThat(tree.srcs()).hasSize(1);
-    assertThat(tree.srcs().get(0).value()).isEqualTo("src");
-    assertThat(tree.dest().value()).isEqualTo("dest");
+    ArgumentAssert.assertThat(tree.srcs().get(0)).hasValue("src");
+    ArgumentAssert.assertThat(tree.dest()).hasValue("dest");
   }
 }

--- a/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/CmdInstructionImplTest.java
+++ b/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/CmdInstructionImplTest.java
@@ -19,10 +19,7 @@
  */
 package org.sonar.iac.docker.tree.impl;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
-import org.sonar.api.batch.fs.TextRange;
 import org.sonar.iac.docker.parser.grammar.DockerLexicalGrammar;
 import org.sonar.iac.docker.parser.utils.Assertions;
 import org.sonar.iac.docker.tree.api.CmdInstruction;
@@ -105,11 +102,6 @@ class CmdInstructionImplTest {
 
     assertThat(tree.arguments()).isNotNull();
     assertArgumentsValue(tree.arguments(), "executable", "param1", "param2");
-    List<TextRange> textRanges = tree.arguments()
-      .stream().map(ArgumentUtils::resolve).map(ArgumentUtils.ArgumentResolution::textRange).collect(Collectors.toList());
-    assertTextRange(textRanges.get(0)).hasRange(1,4,1,14);
-    assertTextRange(textRanges.get(1)).hasRange(1,15,1,21);
-    assertTextRange(textRanges.get(2)).hasRange(1,22,1,28);
 
     assertThat(((SyntaxToken)tree.children().get(0)).value()).isEqualTo("CMD");
     assertThat(tree.children().get(1)).isInstanceOf(ShellForm.class);

--- a/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/CopyInstructionImplTest.java
+++ b/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/CopyInstructionImplTest.java
@@ -22,6 +22,7 @@ package org.sonar.iac.docker.tree.impl;
 import org.junit.jupiter.api.Test;
 import org.sonar.iac.docker.parser.grammar.DockerLexicalGrammar;
 import org.sonar.iac.docker.parser.utils.Assertions;
+import org.sonar.iac.docker.tree.api.ArgumentAssert;
 import org.sonar.iac.docker.tree.api.CopyInstruction;
 import org.sonar.iac.docker.tree.api.DockerTree;
 import org.sonar.iac.docker.tree.api.Flag;
@@ -84,9 +85,10 @@ class CopyInstructionImplTest {
     assertThat(tree.arguments()).isNotNull();
     assertThat(tree.options()).isEmpty();
     assertThat(tree.srcs()).hasSize(2);
-    assertThat(tree.srcs().get(0).value()).isEqualTo("src1");
-    assertThat(tree.srcs().get(1).value()).isEqualTo("src2");
-    assertThat(tree.dest().value()).isEqualTo("dest");
+
+    ArgumentAssert.assertThat(tree.srcs().get(0)).hasValue("src1");
+    ArgumentAssert.assertThat(tree.srcs().get(1)).hasValue("src2");
+    ArgumentAssert.assertThat(tree.dest()).hasValue("dest");
   }
 
   @Test
@@ -96,9 +98,9 @@ class CopyInstructionImplTest {
     assertThat(tree.options()).isEmpty();
     assertThat(tree.arguments()).isNotNull();
     assertThat(tree.srcs()).hasSize(2);
-    assertThat(tree.srcs().get(0).value()).isEqualTo("src1");
-    assertThat(tree.srcs().get(1).value()).isEqualTo("src2");
-    assertThat(tree.dest().value()).isEqualTo("dest");
+    ArgumentAssert.assertThat(tree.srcs().get(0)).hasValue("src1");
+    ArgumentAssert.assertThat(tree.srcs().get(1)).hasValue("src2");
+    ArgumentAssert.assertThat(tree.dest()).hasValue("dest");
   }
 
   @Test
@@ -114,8 +116,8 @@ class CopyInstructionImplTest {
     assertThat(ArgumentUtils.resolve(option.value()).value()).isEqualTo("55:mygroup");
 
     assertThat(tree.srcs()).hasSize(1);
-    assertThat(tree.srcs().get(0).value()).isEqualTo("files*");
-    assertThat(tree.dest().value()).isEqualTo("/somedir/");
+    ArgumentAssert.assertThat(tree.srcs().get(0)).hasValue("files*");
+    ArgumentAssert.assertThat(tree.dest()).hasValue("/somedir/");
   }
 
   @Test
@@ -131,8 +133,8 @@ class CopyInstructionImplTest {
     assertThat(option.value()).isNull();
 
     assertThat(tree.srcs()).hasSize(1);
-    assertThat(tree.srcs().get(0).value()).isEqualTo("src");
-    assertThat(tree.dest().value()).isEqualTo("dest");
+    ArgumentAssert.assertThat(tree.srcs().get(0)).hasValue("src");
+    ArgumentAssert.assertThat(tree.dest()).hasValue("dest");
   }
 
   void copyInstructionHeredocForm() {

--- a/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/EntrypointInstructionImplTest.java
+++ b/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/EntrypointInstructionImplTest.java
@@ -19,10 +19,7 @@
  */
 package org.sonar.iac.docker.tree.impl;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
-import org.sonar.api.batch.fs.TextRange;
 import org.sonar.iac.docker.parser.grammar.DockerLexicalGrammar;
 import org.sonar.iac.docker.parser.utils.Assertions;
 import org.sonar.iac.docker.tree.api.DockerTree;
@@ -100,13 +97,6 @@ class EntrypointInstructionImplTest {
     assertTextRange(tree.textRange()).hasRange(1,0,1,35);
 
     assertArgumentsValue(tree.arguments(), "executable", "param1", "param2");
-    List<TextRange> textRanges = tree.arguments().stream()
-      .map(ArgumentUtils::resolve)
-      .map(ArgumentUtils.ArgumentResolution::textRange)
-      .collect(Collectors.toList());
-    assertTextRange(textRanges.get(0)).hasRange(1,11,1,21);
-    assertTextRange(textRanges.get(1)).hasRange(1,22,1,28);
-    assertTextRange(textRanges.get(2)).hasRange(1,29,1,35);
   }
 
   @Test

--- a/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/OnBuildInstructionImplTest.java
+++ b/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/OnBuildInstructionImplTest.java
@@ -25,16 +25,16 @@ import org.sonar.iac.docker.parser.grammar.DockerLexicalGrammar;
 import org.sonar.iac.docker.parser.utils.Assertions;
 import org.sonar.iac.docker.tree.api.Argument;
 import org.sonar.iac.docker.tree.api.DockerTree;
+import org.sonar.iac.docker.tree.api.KeyValuePair;
+import org.sonar.iac.docker.tree.api.KeyValuePairAssert;
 import org.sonar.iac.docker.tree.api.LabelInstruction;
 import org.sonar.iac.docker.tree.api.Literal;
-import org.sonar.iac.docker.tree.api.KeyValuePair;
 import org.sonar.iac.docker.tree.api.OnBuildInstruction;
 import org.sonar.iac.docker.tree.api.StopSignalInstruction;
 import org.sonar.iac.docker.tree.api.SyntaxToken;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.sonar.iac.common.testing.TextRangeAssert.assertTextRange;
-import static org.sonar.iac.docker.TestUtils.argValue;
 import static org.sonar.iac.docker.tree.impl.DockerTestUtils.parse;
 
 class OnBuildInstructionImplTest {
@@ -97,10 +97,8 @@ class OnBuildInstructionImplTest {
     assertThat(label.children()).hasSize(7);
 
     List<KeyValuePair> labels = label.labels();
-    assertLabel(labels.get(0), "key1", "value1");
-    assertLabel(labels.get(1), "key2", "value2");
-
-
+    KeyValuePairAssert.assertThat(labels.get(0)).hasKey("key1").hasValue("value1");
+    KeyValuePairAssert.assertThat(labels.get(1)).hasKey("key2").hasValue("value2");
   }
 
   @Test
@@ -127,10 +125,5 @@ class OnBuildInstructionImplTest {
     assertThat(((Literal)stopSignal.signal().expressions().get(0)).value()).isEqualTo("SIGKILL");
     assertThat(((SyntaxToken)stopSignal.children().get(0)).value()).isEqualTo("STOPSIGNAL");
     assertThat(((Literal) ((Argument)stopSignal.children().get(1)).expressions().get(0)).value()).isEqualTo("SIGKILL");
-  }
-
-  private static void assertLabel(KeyValuePair label, String expectedKey, String expectedValue) {
-    assertThat(argValue(label.key())).isEqualTo(expectedKey);
-    assertThat(argValue(label.value())).isEqualTo(expectedValue);
   }
 }

--- a/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/RunInstructionImplTest.java
+++ b/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/RunInstructionImplTest.java
@@ -19,17 +19,14 @@
  */
 package org.sonar.iac.docker.tree.impl;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
-import org.sonar.api.batch.fs.TextRange;
 import org.sonar.iac.docker.parser.grammar.DockerLexicalGrammar;
 import org.sonar.iac.docker.parser.utils.Assertions;
+import org.sonar.iac.docker.tree.api.DockerTree;
+import org.sonar.iac.docker.tree.api.ExecForm;
 import org.sonar.iac.docker.tree.api.Flag;
 import org.sonar.iac.docker.tree.api.Literal;
 import org.sonar.iac.docker.tree.api.RunInstruction;
-import org.sonar.iac.docker.tree.api.DockerTree;
-import org.sonar.iac.docker.tree.api.ExecForm;
 import org.sonar.iac.docker.tree.api.ShellForm;
 import org.sonar.iac.docker.tree.api.SyntaxToken;
 import org.sonar.iac.docker.utils.ArgumentUtils;
@@ -190,13 +187,6 @@ class RunInstructionImplTest {
     assertTextRange(tree.textRange()).hasRange(1,0,1,28);
 
     assertArgumentsValue(tree.arguments(), "executable", "param1", "param2");
-    List<TextRange> textRanges = tree.arguments().stream()
-      .map(ArgumentUtils::resolve)
-      .map(ArgumentUtils.ArgumentResolution::textRange)
-      .collect(Collectors.toList());
-    assertTextRange(textRanges.get(0)).hasRange(1,4,1,14);
-    assertTextRange(textRanges.get(1)).hasRange(1,15,1,21);
-    assertTextRange(textRanges.get(2)).hasRange(1,22,1,28);
 
     assertThat(((SyntaxToken)tree.children().get(0)).value()).isEqualTo("RUN");
     assertThat(tree.children().get(1)).isInstanceOf(ShellForm.class);
@@ -237,13 +227,6 @@ class RunInstructionImplTest {
     assertTextRange(option.textRange()).hasRange(1,4,1,35);
 
     assertArgumentsValue(tree.arguments(), "executable", "param1", "param2");
-    List<TextRange> textRanges = tree.arguments().stream()
-      .map(ArgumentUtils::resolve)
-      .map(ArgumentUtils.ArgumentResolution::textRange)
-      .collect(Collectors.toList());
-    assertTextRange(textRanges.get(0)).hasRange(1,36,1,46);
-    assertTextRange(textRanges.get(1)).hasRange(1,47,1,53);
-    assertTextRange(textRanges.get(2)).hasRange(1,54,1,60);
 
     assertThat(((SyntaxToken)tree.children().get(0)).value()).isEqualTo("RUN");
     assertThat(tree.children().get(1)).isInstanceOf(Flag.class);

--- a/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/ShellFormImplTest.java
+++ b/iac-extensions/docker/src/test/java/org/sonar/iac/docker/tree/impl/ShellFormImplTest.java
@@ -22,14 +22,13 @@ package org.sonar.iac.docker.tree.impl;
 import org.junit.jupiter.api.Test;
 import org.sonar.iac.docker.parser.grammar.DockerLexicalGrammar;
 import org.sonar.iac.docker.parser.utils.Assertions;
+import org.sonar.iac.docker.tree.api.ArgumentAssert;
 import org.sonar.iac.docker.tree.api.DockerTree;
 import org.sonar.iac.docker.tree.api.EncapsulatedVariable;
 import org.sonar.iac.docker.tree.api.ShellForm;
-import org.sonar.iac.docker.tree.api.SyntaxToken;
 import org.sonar.iac.docker.utils.ArgumentUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.sonar.iac.common.testing.TextRangeAssert.assertTextRange;
 import static org.sonar.iac.docker.TestUtils.assertArgumentsValue;
 
 class ShellFormImplTest {
@@ -87,15 +86,10 @@ class ShellFormImplTest {
 
     ArgumentUtils.ArgumentResolution argResolved1 = ArgumentUtils.resolve(shellForm.arguments().get(0));
     assertThat(argResolved1.value()).isEqualTo("executable");
-    assertTextRange(argResolved1.textRange()).hasRange(1, 1, 1, 11);
-    SyntaxToken token1 = argResolved1.asSyntaxToken();
-    assertThat(token1.value()).isEqualTo("executable");
-    assertTextRange(token1.textRange()).hasRange(1, 1, 1, 11);
 
     ArgumentUtils.ArgumentResolution argResolved2 = ArgumentUtils.resolve(shellForm.arguments().get(1));
     assertThat(argResolved2.value()).isNull();
-    assertTextRange(argResolved2.textRange()).isNull();
-    assertThat(argResolved2.asSyntaxToken()).isNull();
+    ArgumentAssert.assertThat(shellForm.arguments().get(1)).isUnresolved();
   }
 
   @Test
@@ -116,6 +110,6 @@ class ShellFormImplTest {
     EncapsulatedVariable var = (EncapsulatedVariable) shellForm.arguments().get(0).expressions().get(0);
     assertThat(var.identifier()).isEqualTo("var");
     assertThat(var.modifierSeparator()).isNull();
-    assertThat(ArgumentUtils.resolve(var.modifier()).value()).isEqualTo("%%[a-z]+");
+    ArgumentAssert.assertThat(var.modifier()).hasValue("%%[a-z]+");
   }
 }

--- a/iac-extensions/docker/src/test/java/org/sonar/iac/docker/utils/ArgumentUtilsTest.java
+++ b/iac-extensions/docker/src/test/java/org/sonar/iac/docker/utils/ArgumentUtilsTest.java
@@ -31,7 +31,6 @@ import org.sonar.iac.docker.tree.api.Expression;
 import org.sonar.iac.docker.tree.api.File;
 import org.sonar.iac.docker.tree.api.KeyValuePair;
 import org.sonar.iac.docker.tree.api.LabelInstruction;
-import org.sonar.iac.docker.tree.api.SyntaxToken;
 import org.sonar.iac.docker.tree.impl.ArgumentImpl;
 import org.sonar.iac.docker.tree.impl.LiteralImpl;
 import org.sonar.iac.docker.visitors.DockerSymbolVisitor;
@@ -58,8 +57,6 @@ class ArgumentUtilsTest {
     assertThat(ArgumentUtils.resolve(argument)).extracting(ArgumentUtils.ArgumentResolution::value)
       .isNotNull()
       .isEqualTo("foo");
-    SyntaxToken token = ArgumentUtils.argumentToSyntaxToken(argument);
-    assertThat(token).isNotNull();
   }
 
   @ParameterizedTest
@@ -74,8 +71,6 @@ class ArgumentUtilsTest {
     Argument argument = parseArgument(input);
     assertThat(ArgumentUtils.resolve(argument)).extracting(ArgumentUtils.ArgumentResolution::value)
       .isNull();
-    SyntaxToken token = ArgumentUtils.argumentToSyntaxToken(argument);
-    assertThat(token).isNull();
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Sorry for the large PR. I introduced a new assertion class and replaced old ones. 
The PR also solves "[SONARIAC-594](https://sonarsource.atlassian.net/browse/SONARIAC-594) Get rid of SyntaxTokenUtils"

[SONARIAC-594]: https://sonarsource.atlassian.net/browse/SONARIAC-594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ