### PR TITLE
Set fail-fast property for ITs

### DIFF
--- a/its/ruling/src/test/java/org/sonarsource/iac/IacRulingTest.java
+++ b/its/ruling/src/test/java/org/sonarsource/iac/IacRulingTest.java
@@ -139,6 +139,7 @@ class IacRulingTest {
       .setProperty("sonar.lits.dump.new", actualDirectory.getAbsolutePath())
       .setProperty("sonar.lits.differences", litsDifferencesFile.getAbsolutePath())
       .setProperty("sonar.scm.disabled", "true")
+      .setProperty("sonar.internal.analysis.failFast", "true")
       .setProperty("sonar.project", project)
       .setEnvironmentVariable("SONAR_RUNNER_OPTS", "-Xmx1024m");
 


### PR DESCRIPTION
We can make use of the fail-fast property for our ruling ITs. This way we can already identify issues within checks before merging on the master.