### PR TITLE
SONARIAC-636  Add wrapper to AnalysisWarnings to allow sensor initialization in SonarLint context

### DIFF
--- a/iac-common/src/main/java/org/sonar/iac/common/warnings/AnalysisWarningsWrapper.java
+++ b/iac-common/src/main/java/org/sonar/iac/common/warnings/AnalysisWarningsWrapper.java
@@ -17,24 +17,11 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonar.plugins.iac;
+package org.sonar.iac.common.warnings;
 
-import org.sonar.api.Plugin;
-import org.sonar.iac.cloudformation.plugin.CloudformationExtension;
-import org.sonar.iac.common.warnings.DefaultAnalysisWarningsWrapper;
-import org.sonar.iac.docker.plugin.DockerExtension;
-import org.sonar.iac.kubernetes.plugin.KubernetesExtension;
-import org.sonar.iac.terraform.plugin.TerraformExtension;
+import org.sonar.api.scanner.ScannerSide;
 
-public class IacPlugin implements Plugin {
-
-  @Override
-  public void define(Context context) {
-    TerraformExtension.define(context);
-    CloudformationExtension.define(context);
-    KubernetesExtension.define(context);
-    DockerExtension.define(context);
-
-    context.addExtension(DefaultAnalysisWarningsWrapper.class);
-  }
+@ScannerSide
+public interface AnalysisWarningsWrapper {
+  void addWarning(String text);
 }

--- a/iac-common/src/main/java/org/sonar/iac/common/warnings/DefaultAnalysisWarningsWrapper.java
+++ b/iac-common/src/main/java/org/sonar/iac/common/warnings/DefaultAnalysisWarningsWrapper.java
@@ -17,24 +17,29 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonar.plugins.iac;
+package org.sonar.iac.common.warnings;
 
-import org.sonar.api.Plugin;
-import org.sonar.iac.cloudformation.plugin.CloudformationExtension;
-import org.sonar.iac.common.warnings.DefaultAnalysisWarningsWrapper;
-import org.sonar.iac.docker.plugin.DockerExtension;
-import org.sonar.iac.kubernetes.plugin.KubernetesExtension;
-import org.sonar.iac.terraform.plugin.TerraformExtension;
+import org.sonar.api.notifications.AnalysisWarnings;
 
-public class IacPlugin implements Plugin {
+public class DefaultAnalysisWarningsWrapper implements AnalysisWarningsWrapper {
 
-  @Override
-  public void define(Context context) {
-    TerraformExtension.define(context);
-    CloudformationExtension.define(context);
-    KubernetesExtension.define(context);
-    DockerExtension.define(context);
+  private final AnalysisWarnings analysisWarnings;
 
-    context.addExtension(DefaultAnalysisWarningsWrapper.class);
+  public DefaultAnalysisWarningsWrapper(AnalysisWarnings analysisWarnings) {
+    this.analysisWarnings = analysisWarnings;
+  }
+
+  /**
+   * Noop instance which can be used as placeholder when {@link AnalysisWarnings} is not supported
+   */
+  public static final AnalysisWarningsWrapper NOOP_ANALYSIS_WARNINGS = new DefaultAnalysisWarningsWrapper(null) {
+    @Override
+    public void addWarning(String text) {
+      // no operation
+    }
+  };
+
+  public void addWarning(String text) {
+    this.analysisWarnings.addUnique(text);
   }
 }

--- a/iac-common/src/main/java/org/sonar/iac/common/warnings/package-info.java
+++ b/iac-common/src/main/java/org/sonar/iac/common/warnings/package-info.java
@@ -17,24 +17,4 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonar.plugins.iac;
-
-import org.sonar.api.Plugin;
-import org.sonar.iac.cloudformation.plugin.CloudformationExtension;
-import org.sonar.iac.common.warnings.DefaultAnalysisWarningsWrapper;
-import org.sonar.iac.docker.plugin.DockerExtension;
-import org.sonar.iac.kubernetes.plugin.KubernetesExtension;
-import org.sonar.iac.terraform.plugin.TerraformExtension;
-
-public class IacPlugin implements Plugin {
-
-  @Override
-  public void define(Context context) {
-    TerraformExtension.define(context);
-    CloudformationExtension.define(context);
-    KubernetesExtension.define(context);
-    DockerExtension.define(context);
-
-    context.addExtension(DefaultAnalysisWarningsWrapper.class);
-  }
-}
+package org.sonar.iac.common.warnings;

--- a/iac-common/src/test/java/org/sonar/iac/common/warnings/DefaultAnalysisWarningsWrapperTest.java
+++ b/iac-common/src/test/java/org/sonar/iac/common/warnings/DefaultAnalysisWarningsWrapperTest.java
@@ -22,6 +22,7 @@ package org.sonar.iac.common.warnings;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.notifications.AnalysisWarnings;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -34,5 +35,11 @@ class DefaultAnalysisWarningsWrapperTest {
     analysisWarningsWrapper.addWarning("Test");
 
     verify(analysisWarnings).addUnique("Test");
+  }
+
+  @Test
+  void addWarningOnNoopWrapper() {
+    AnalysisWarningsWrapper analysisWarningsWrapper = DefaultAnalysisWarningsWrapper.NOOP_ANALYSIS_WARNINGS;
+    assertDoesNotThrow(() -> analysisWarningsWrapper.addWarning("Test"));
   }
 }

--- a/iac-common/src/test/java/org/sonar/iac/common/warnings/DefaultAnalysisWarningsWrapperTest.java
+++ b/iac-common/src/test/java/org/sonar/iac/common/warnings/DefaultAnalysisWarningsWrapperTest.java
@@ -17,24 +17,22 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonar.plugins.iac;
+package org.sonar.iac.common.warnings;
 
-import org.sonar.api.Plugin;
-import org.sonar.iac.cloudformation.plugin.CloudformationExtension;
-import org.sonar.iac.common.warnings.DefaultAnalysisWarningsWrapper;
-import org.sonar.iac.docker.plugin.DockerExtension;
-import org.sonar.iac.kubernetes.plugin.KubernetesExtension;
-import org.sonar.iac.terraform.plugin.TerraformExtension;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.notifications.AnalysisWarnings;
 
-public class IacPlugin implements Plugin {
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
-  @Override
-  public void define(Context context) {
-    TerraformExtension.define(context);
-    CloudformationExtension.define(context);
-    KubernetesExtension.define(context);
-    DockerExtension.define(context);
+class DefaultAnalysisWarningsWrapperTest {
 
-    context.addExtension(DefaultAnalysisWarningsWrapper.class);
+  @Test
+  void addWarning() {
+    AnalysisWarnings analysisWarnings = spy(AnalysisWarnings.class);
+    AnalysisWarningsWrapper analysisWarningsWrapper = new DefaultAnalysisWarningsWrapper(analysisWarnings);
+    analysisWarningsWrapper.addWarning("Test");
+
+    verify(analysisWarnings).addUnique("Test");
   }
 }

--- a/iac-extensions/cloudformation/src/main/java/org/sonar/iac/cloudformation/plugin/CloudformationSensor.java
+++ b/iac-extensions/cloudformation/src/main/java/org/sonar/iac/cloudformation/plugin/CloudformationSensor.java
@@ -29,7 +29,6 @@ import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.FileLinesContextFactory;
-import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.iac.cloudformation.checks.CloudformationCheckList;
@@ -37,18 +36,25 @@ import org.sonar.iac.cloudformation.parser.CloudformationConverter;
 import org.sonar.iac.cloudformation.reports.CfnLintImporter;
 import org.sonar.iac.common.api.tree.Tree;
 import org.sonar.iac.common.extension.TreeParser;
+import org.sonar.iac.common.warnings.AnalysisWarningsWrapper;
 import org.sonar.iac.common.yaml.YamlParser;
 import org.sonar.iac.common.yaml.YamlSensor;
 import org.sonarsource.analyzer.commons.ExternalReportProvider;
+
+import static org.sonar.iac.common.warnings.DefaultAnalysisWarningsWrapper.NOOP_ANALYSIS_WARNINGS;
 
 public class CloudformationSensor extends YamlSensor {
 
   private static final int DEFAULT_BUFFER_SIZE = 8192;
 
-  private final AnalysisWarnings analysisWarnings;
+  private final AnalysisWarningsWrapper analysisWarnings;
 
   public CloudformationSensor(SonarRuntime sonarRuntime, FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory,
-                              NoSonarFilter noSonarFilter, CloudformationLanguage language, AnalysisWarnings analysisWarnings) {
+                              NoSonarFilter noSonarFilter, CloudformationLanguage language) {
+    this(sonarRuntime, fileLinesContextFactory, checkFactory, noSonarFilter, language, NOOP_ANALYSIS_WARNINGS);
+  }
+  public CloudformationSensor(SonarRuntime sonarRuntime, FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory,
+                              NoSonarFilter noSonarFilter, CloudformationLanguage language, AnalysisWarningsWrapper analysisWarnings) {
     super(sonarRuntime, fileLinesContextFactory, checkFactory, noSonarFilter, language, CloudformationCheckList.checks());
     this.analysisWarnings = analysisWarnings;
   }

--- a/iac-extensions/cloudformation/src/main/java/org/sonar/iac/cloudformation/reports/CfnLintImporter.java
+++ b/iac-extensions/cloudformation/src/main/java/org/sonar/iac/cloudformation/reports/CfnLintImporter.java
@@ -29,10 +29,10 @@ import org.sonar.api.batch.fs.TextRange;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.issue.NewExternalIssue;
 import org.sonar.api.batch.sensor.issue.NewIssueLocation;
-import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
 import org.sonar.iac.cloudformation.plugin.CfnLintRulesDefinition;
+import org.sonar.iac.common.warnings.AnalysisWarningsWrapper;
 import org.sonarsource.analyzer.commons.internal.json.simple.JSONArray;
 import org.sonarsource.analyzer.commons.internal.json.simple.JSONObject;
 import org.sonarsource.analyzer.commons.internal.json.simple.parser.JSONParser;
@@ -48,7 +48,7 @@ public class CfnLintImporter {
   private CfnLintImporter() {
   }
 
-  public static void importReport(SensorContext context, File reportFile, AnalysisWarnings analysisWarnings) {
+  public static void importReport(SensorContext context, File reportFile, AnalysisWarningsWrapper analysisWarnings) {
     String path = reportFile.getPath();
     if (!reportFile.isFile()) {
       String message = String.format("Cfn-lint report importing: path does not seem to point to a file %s", path);
@@ -139,8 +139,8 @@ public class CfnLintImporter {
     return Math.toIntExact((long) o);
   }
 
-  private static void logWarnAndAddUnique(AnalysisWarnings analysisWarnings, String message) {
+  private static void logWarnAndAddUnique(AnalysisWarningsWrapper analysisWarnings, String message) {
     LOG.warn(message);
-    analysisWarnings.addUnique(message);
+    analysisWarnings.addWarning(message);
   }
 }

--- a/iac-extensions/cloudformation/src/test/java/org/sonar/iac/cloudformation/plugin/CfnLintImporterTest.java
+++ b/iac-extensions/cloudformation/src/test/java/org/sonar/iac/cloudformation/plugin/CfnLintImporterTest.java
@@ -32,11 +32,11 @@ import org.mockito.Mockito;
 import org.sonar.api.batch.fs.internal.TestInputFileBuilder;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.batch.sensor.issue.ExternalIssue;
-import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.rules.RuleType;
 import org.sonar.api.utils.log.LogTesterJUnit5;
 import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.iac.cloudformation.reports.CfnLintImporter;
+import org.sonar.iac.common.warnings.AnalysisWarningsWrapper;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.Mockito.doAnswer;
@@ -52,7 +52,7 @@ class CfnLintImporterTest {
   public LogTesterJUnit5 logTester = new LogTesterJUnit5();
   private SensorContextTester context;
 
-  private final AnalysisWarnings mockAnalysisWarnings = mock(AnalysisWarnings.class);
+  private final AnalysisWarningsWrapper mockAnalysisWarnings = mock(AnalysisWarningsWrapper.class);
 
   @BeforeEach
   void setUp() throws IOException {
@@ -76,7 +76,7 @@ class CfnLintImporterTest {
     importReport(reportFile);
     assertThat(logTester.logs(LoggerLevel.WARN))
       .containsExactly(logMessage);
-    verify(mockAnalysisWarnings, times(1)).addUnique(logMessage);
+    verify(mockAnalysisWarnings, times(1)).addWarning(logMessage);
   }
 
   @Test
@@ -91,7 +91,7 @@ class CfnLintImporterTest {
     importReport(reportFile);
     assertThat(logTester.logs(LoggerLevel.WARN))
       .containsExactly(logMessage);
-    verify(mockAnalysisWarnings, times(1)).addUnique(logMessage);
+    verify(mockAnalysisWarnings, times(1)).addWarning(logMessage);
   }
 
   @Test
@@ -110,7 +110,7 @@ class CfnLintImporterTest {
     assertThat(context.allExternalIssues()).isEmpty();
     assertThat(logTester.logs(LoggerLevel.WARN))
       .containsExactly(logMessage);
-    verify(mockAnalysisWarnings, times(1)).addUnique(logMessage);
+    verify(mockAnalysisWarnings, times(1)).addWarning(logMessage);
   }
 
   @Test
@@ -134,7 +134,7 @@ class CfnLintImporterTest {
     String logMessage = String.format("Cfn-lint report importing: could not save 1 out of 2 issues from %s", reportFile.getPath());
     assertThat(logTester.logs(LoggerLevel.WARN))
       .containsExactly(logMessage);
-    verify(mockAnalysisWarnings, times(1)).addUnique(logMessage);
+    verify(mockAnalysisWarnings, times(1)).addWarning(logMessage);
   }
 
   @Test

--- a/iac-extensions/cloudformation/src/test/java/org/sonar/iac/cloudformation/plugin/CloudformationSensorTest.java
+++ b/iac-extensions/cloudformation/src/test/java/org/sonar/iac/cloudformation/plugin/CloudformationSensorTest.java
@@ -27,13 +27,11 @@ import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.issue.Issue;
 import org.sonar.api.config.internal.MapSettings;
-import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.utils.log.LoggerLevel;
 import org.sonar.iac.common.testing.ExtensionSensorTest;
 import org.sonar.iac.common.testing.IacTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.spy;
 
 class CloudformationSensorTest extends ExtensionSensorTest {
 
@@ -109,7 +107,7 @@ class CloudformationSensorTest extends ExtensionSensorTest {
 
   @Override
   protected CloudformationSensor sensor(CheckFactory checkFactory) {
-    return new CloudformationSensor(SONAR_RUNTIME_8_9, fileLinesContextFactory, checkFactory, noSonarFilter, new CloudformationLanguage(), spy(AnalysisWarnings.class));
+    return new CloudformationSensor(SONAR_RUNTIME_8_9, fileLinesContextFactory, checkFactory, noSonarFilter, new CloudformationLanguage());
   }
 
   @Override

--- a/iac-extensions/terraform/src/main/java/org/sonar/iac/terraform/plugin/TerraformProviders.java
+++ b/iac-extensions/terraform/src/main/java/org/sonar/iac/terraform/plugin/TerraformProviders.java
@@ -24,11 +24,13 @@ import java.util.EnumSet;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.scanner.ScannerSide;
 import org.sonar.api.utils.Version;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
+import org.sonar.iac.common.warnings.AnalysisWarningsWrapper;
+
+import static org.sonar.iac.common.warnings.DefaultAnalysisWarningsWrapper.NOOP_ANALYSIS_WARNINGS;
 
 @ScannerSide
 public class TerraformProviders {
@@ -43,11 +45,15 @@ public class TerraformProviders {
 
   private final EnumMap<Provider.Identifier, Provider> providers = new EnumMap<>(Provider.Identifier.class);
 
-  private final AnalysisWarnings analysisWarnings;
+  private final AnalysisWarningsWrapper analysisWarnings;
 
   private final EnumSet<Provider.Identifier> raisedWarnings = EnumSet.noneOf(Provider.Identifier.class);
 
-  public TerraformProviders(SensorContext sensorContext, AnalysisWarnings analysisWarnings) {
+  public TerraformProviders(SensorContext sensorContext) {
+    this(sensorContext, NOOP_ANALYSIS_WARNINGS);
+  }
+
+  public TerraformProviders(SensorContext sensorContext, AnalysisWarningsWrapper analysisWarnings) {
     this.analysisWarnings = analysisWarnings;
     for (Provider.Identifier identifier : Provider.Identifier.values()) {
       sensorContext.config().get(identifier.key)
@@ -71,7 +77,7 @@ public class TerraformProviders {
 
   private void raiseWarning(Provider.Identifier identifier, String text) {
     if (raisedWarnings.add(identifier)) {
-      analysisWarnings.addUnique(text);
+      analysisWarnings.addWarning(text);
     }
   }
 

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/plugin/TerraformProvidersTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/plugin/TerraformProvidersTest.java
@@ -26,10 +26,10 @@ import org.junit.jupiter.api.io.TempDir;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.config.internal.MapSettings;
-import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.utils.Version;
 import org.sonar.api.utils.log.LogTesterJUnit5;
 import org.sonar.api.utils.log.LoggerLevel;
+import org.sonar.iac.common.warnings.AnalysisWarningsWrapper;
 import org.sonar.iac.terraform.plugin.TerraformProviders.Provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 class TerraformProvidersTest {
 
-  private final AnalysisWarnings analysisWarnings = mock(AnalysisWarnings.class);
+  private final AnalysisWarningsWrapper analysisWarnings = mock(AnalysisWarningsWrapper.class);
 
   private static final String AWS_KEY = "sonar.terraform.provider.aws.version";
   @TempDir
@@ -66,7 +66,7 @@ class TerraformProvidersTest {
     assertThat(logTester.logs(LoggerLevel.WARN))
       .containsExactly("Can not parse provider version \"sonar.terraform.provider.aws.version\". Input: \"v1.3.4\"");
     verify(analysisWarnings, times(1))
-      .addUnique("Can not parse provider version for \"sonar.terraform.provider.aws.version\". " +
+      .addWarning("Can not parse provider version for \"sonar.terraform.provider.aws.version\". " +
         "Please check the format of your used AWS version in the project settings.");
   }
 
@@ -76,7 +76,7 @@ class TerraformProvidersTest {
     Provider provider =  providers.provider(Provider.Identifier.AWS);
     assertThat(provider.providerVersion).isNull();
     verify(analysisWarnings, times(1))
-      .addUnique("Provide the used AWS provider version via the \"sonar.terraform.provider.aws.version\" " +
+      .addWarning("Provide the used AWS provider version via the \"sonar.terraform.provider.aws.version\" " +
         "property to increase the accuracy of your results.");
   }
 
@@ -85,7 +85,7 @@ class TerraformProvidersTest {
     TerraformProviders providers = providers(SensorContextTester.create(baseDir));
     providers.provider(Provider.Identifier.AWS);
     verify(analysisWarnings, times(1))
-      .addUnique("Provide the used AWS provider version via the \"sonar.terraform.provider.aws.version\" " +
+      .addWarning("Provide the used AWS provider version via the \"sonar.terraform.provider.aws.version\" " +
         "property to increase the accuracy of your results.");
   }
 
@@ -95,7 +95,7 @@ class TerraformProvidersTest {
     providers.provider(Provider.Identifier.AWS);
     providers.provider(Provider.Identifier.AWS);
     verify(analysisWarnings, times(1))
-      .addUnique("Provide the used AWS provider version via the \"sonar.terraform.provider.aws.version\" " +
+      .addWarning("Provide the used AWS provider version via the \"sonar.terraform.provider.aws.version\" " +
         "property to increase the accuracy of your results.");
   }
 

--- a/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/plugin/TerraformSensorTest.java
+++ b/iac-extensions/terraform/src/test/java/org/sonar/iac/terraform/plugin/TerraformSensorTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.iac.common.api.tree.impl.TextRange;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.issue.Issue;
@@ -32,15 +31,14 @@ import org.sonar.api.batch.sensor.issue.IssueLocation;
 import org.sonar.api.config.internal.MapSettings;
 import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.measures.CoreMetrics;
-import org.sonar.api.notifications.AnalysisWarnings;
 import org.sonar.api.utils.Version;
 import org.sonar.api.utils.log.LoggerLevel;
+import org.sonar.iac.common.api.tree.impl.TextRange;
 import org.sonar.iac.common.api.tree.impl.TextRanges;
 import org.sonar.iac.common.testing.ExtensionSensorTest;
 import org.sonar.iac.common.testing.TextRangeAssert;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 class TerraformSensorTest extends ExtensionSensorTest {
 
@@ -104,7 +102,7 @@ class TerraformSensorTest extends ExtensionSensorTest {
   }
 
   private TerraformProviders providerVersions() {
-    return new TerraformProviders(context, mock(AnalysisWarnings.class));
+    return new TerraformProviders(context);
   }
 
   @Override

--- a/sonar-iac-plugin/src/test/java/org/sonar/plugins/iac/IacPluginTest.java
+++ b/sonar-iac-plugin/src/test/java/org/sonar/plugins/iac/IacPluginTest.java
@@ -40,7 +40,7 @@ class IacPluginTest {
     SonarRuntime runtime = SonarRuntimeImpl.forSonarQube(VERSION_8_9, SonarQubeSide.SCANNER, SonarEdition.COMMUNITY);
     Plugin.Context context = new Plugin.Context(runtime);
     iacPlugin.define(context);
-    assertThat(context.getExtensions()).hasSize(27);
+    assertThat(context.getExtensions()).hasSize(28);
   }
 }
 


### PR DESCRIPTION
During the implementation of this ticket, I released, that we lack integration tests for the CfnLint report import in the Cloudformation extension as well as for the configuration of an AWS provider version in the Terraform extension. To address these missing ITs, I've created:
* [SONARIAC-661](https://sonarsource.atlassian.net/browse/SONARIAC-661) Add integration test for CfnLint report import
* [SONARIAC-662](https://sonarsource.atlassian.net/browse/SONARIAC-662) Add property integration test for invalid AWS provider versions

Which should be added soon, but are no blockers for a SonarLint integration.

[SONARIAC-661]: https://sonarsource.atlassian.net/browse/SONARIAC-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SONARIAC-662]: https://sonarsource.atlassian.net/browse/SONARIAC-662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ