### PR TITLE
SONARIAC-182 Cfn-lint import error log should convey the reason

### DIFF
--- a/iac-extensions/cloudformation/src/main/java/org/sonar/iac/cloudformation/plugin/CloudformationSensor.java
+++ b/iac-extensions/cloudformation/src/main/java/org/sonar/iac/cloudformation/plugin/CloudformationSensor.java
@@ -77,7 +77,7 @@ public class CloudformationSensor extends YamlSensor {
   @Override
   protected void importExternalReports(SensorContext sensorContext) {
     ExternalReportProvider.getReportFiles(sensorContext, CloudformationSettings.CFN_LINT_REPORTS_KEY)
-      .forEach(report -> CfnLintImporter.importReport(sensorContext, report, analysisWarnings));
+      .forEach(report -> new CfnLintImporter(sensorContext, analysisWarnings).importReport(report));
   }
 
   @Override

--- a/iac-extensions/cloudformation/src/main/java/org/sonar/iac/cloudformation/reports/CfnLintImporter.java
+++ b/iac-extensions/cloudformation/src/main/java/org/sonar/iac/cloudformation/reports/CfnLintImporter.java
@@ -23,8 +23,10 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.fs.TextRange;
@@ -110,9 +112,9 @@ public class CfnLintImporter {
 
     if (inputFile == null) {
       unresolvedPaths.add(path);
-      return;
     }
 
+    Objects.requireNonNull(inputFile);
     String ruleId = (String) ((JSONObject) issueJson.get("Rule")).get("Id");
     if (!CfnLintRulesDefinition.RULE_LOADER.ruleKeys().contains(ruleId)) {
       ruleId = "cfn-lint.fallback";
@@ -133,9 +135,7 @@ public class CfnLintImporter {
     StringBuilder sb = new StringBuilder(String.format("Cfn-lint report importing: could not save %d out of %d issues from %s.", failed, total, path));
     if (!unresolvedPaths.isEmpty()) {
       sb.append(" Some file paths could not be resolved: ");
-      unresolvedPaths.stream()
-        .limit(2)
-        .forEach(p -> sb.append(String.format(", '%s'", p)));
+      sb.append(unresolvedPaths.stream().limit(2).collect(Collectors.joining(", ")));
       sb.append(unresolvedPaths.size() > 2 ? ", ..." : "");
     }
     logWarnAndAddUnique(analysisWarnings, sb.toString());

--- a/iac-extensions/cloudformation/src/test/java/org/sonar/iac/cloudformation/plugin/CfnLintImporterTest.java
+++ b/iac-extensions/cloudformation/src/test/java/org/sonar/iac/cloudformation/plugin/CfnLintImporterTest.java
@@ -105,7 +105,7 @@ class CfnLintImporterTest {
   @Test
   void invalid_issue() {
     File reportFile = new File("src/test/resources/cfn-lint/invalidIssue.json");
-    String logMessage = String.format("Cfn-lint report importing: could not save 1 out of 1 issues from %s", reportFile.getPath());
+    String logMessage = String.format("Cfn-lint report importing: could not save 1 out of 1 issues from %s.", reportFile.getPath());
     importReport(reportFile);
     assertThat(context.allExternalIssues()).isEmpty();
     assertThat(logTester.logs(LoggerLevel.WARN))
@@ -131,7 +131,7 @@ class CfnLintImporterTest {
     File reportFile = new File("src/test/resources/cfn-lint/validAndInvalid.json");
     importReport(reportFile);
     assertThat(context.allExternalIssues()).hasSize(1);
-    String logMessage = String.format("Cfn-lint report importing: could not save 1 out of 2 issues from %s", reportFile.getPath());
+    String logMessage = String.format("Cfn-lint report importing: could not save 1 out of 2 issues from %s.", reportFile.getPath());
     assertThat(logTester.logs(LoggerLevel.WARN))
       .containsExactly(logMessage);
     verify(mockAnalysisWarnings, times(1)).addWarning(logMessage);
@@ -149,6 +149,6 @@ class CfnLintImporterTest {
   }
 
   private void importReport(File reportFile) {
-    CfnLintImporter.importReport(context, reportFile, mockAnalysisWarnings);
+    new CfnLintImporter(context, mockAnalysisWarnings).importReport(reportFile);
   }
 }

--- a/iac-extensions/cloudformation/src/test/java/org/sonar/iac/cloudformation/plugin/CfnLintImporterTest.java
+++ b/iac-extensions/cloudformation/src/test/java/org/sonar/iac/cloudformation/plugin/CfnLintImporterTest.java
@@ -74,8 +74,7 @@ class CfnLintImporterTest {
     String logMessage = String.format(expectedLog, path);
 
     importReport(reportFile);
-    assertThat(logTester.logs(LoggerLevel.WARN))
-      .containsExactly(logMessage);
+    assertThat(logTester.logs(LoggerLevel.WARN)).containsExactly(logMessage);
     verify(mockAnalysisWarnings, times(1)).addWarning(logMessage);
   }
 
@@ -89,8 +88,7 @@ class CfnLintImporterTest {
     doAnswer((invocation) -> {throw new IOException();}).when(reportFile).toPath();
 
     importReport(reportFile);
-    assertThat(logTester.logs(LoggerLevel.WARN))
-      .containsExactly(logMessage);
+    assertThat(logTester.logs(LoggerLevel.WARN)).containsExactly(logMessage);
     verify(mockAnalysisWarnings, times(1)).addWarning(logMessage);
   }
 
@@ -108,8 +106,7 @@ class CfnLintImporterTest {
     String logMessage = String.format("Cfn-lint report importing: could not save 1 out of 1 issues from %s.", reportFile.getPath());
     importReport(reportFile);
     assertThat(context.allExternalIssues()).isEmpty();
-    assertThat(logTester.logs(LoggerLevel.WARN))
-      .containsExactly(logMessage);
+    assertThat(logTester.logs(LoggerLevel.WARN)).containsExactly(logMessage);
     verify(mockAnalysisWarnings, times(1)).addWarning(logMessage);
   }
 
@@ -157,10 +154,11 @@ class CfnLintImporterTest {
   }, delimiter = ';')
   void unresolvedPathsAreAddedToWarning(File reportFile, String expectedLogFormat) {
     String expectedLog = String.format(expectedLogFormat, reportFile.getPath());
+
     importReport(reportFile);
+
     assertThat(context.allExternalIssues()).isEmpty();
-    assertThat(logTester.logs(LoggerLevel.WARN))
-      .containsExactly(expectedLog);
+    assertThat(logTester.logs(LoggerLevel.WARN)).containsExactly(expectedLog);
     verify(mockAnalysisWarnings, times(1)).addWarning(expectedLog);
   }
 

--- a/iac-extensions/cloudformation/src/test/java/org/sonar/iac/cloudformation/plugin/CfnLintImporterTest.java
+++ b/iac-extensions/cloudformation/src/test/java/org/sonar/iac/cloudformation/plugin/CfnLintImporterTest.java
@@ -148,6 +148,22 @@ class CfnLintImporterTest {
     verifyNoInteractions(mockAnalysisWarnings);
   }
 
+  @ParameterizedTest
+  @CsvSource(value = {
+    "src/test/resources/cfn-lint/invalidPathTwo.json; Cfn-lint report importing: could not save 2 out of 2 issues from %s. Some file paths could not be resolved: " +
+      "doesNotExist.yaml, a/b/doesNotExistToo.yaml",
+    "src/test/resources/cfn-lint/invalidPathMoreThanTwo.json; Cfn-lint report importing: could not save 3 out of 3 issues from %s. Some file paths could not be resolved: " +
+      "doesNotExist.yaml, a/b/doesNotExistToo.yaml, ..."
+  }, delimiter = ';')
+  void unresolvedPathsAreAddedToWarning(File reportFile, String expectedLogFormat) {
+    String expectedLog = String.format(expectedLogFormat, reportFile.getPath());
+    importReport(reportFile);
+    assertThat(context.allExternalIssues()).isEmpty();
+    assertThat(logTester.logs(LoggerLevel.WARN))
+      .containsExactly(expectedLog);
+    verify(mockAnalysisWarnings, times(1)).addWarning(expectedLog);
+  }
+
   private void importReport(File reportFile) {
     new CfnLintImporter(context, mockAnalysisWarnings).importReport(reportFile);
   }

--- a/iac-extensions/cloudformation/src/test/resources/cfn-lint/invalidPathMoreThanTwo.json
+++ b/iac-extensions/cloudformation/src/test/resources/cfn-lint/invalidPathMoreThanTwo.json
@@ -1,0 +1,11 @@
+[
+  {
+    "Filename": "doesNotExist.yaml"
+  },
+  {
+    "Filename": "a/b/doesNotExistToo.yaml"
+  },
+  {
+    "Filename": "thirdOneThatDoesNotExist"
+  }
+]

--- a/iac-extensions/cloudformation/src/test/resources/cfn-lint/invalidPathTwo.json
+++ b/iac-extensions/cloudformation/src/test/resources/cfn-lint/invalidPathTwo.json
@@ -4,5 +4,5 @@
   },
   {
     "Filename": "a/b/doesNotExistToo.yaml"
-  },
+  }
 ]

--- a/iac-extensions/cloudformation/src/test/resources/cfn-lint/invalidPathTwo.json
+++ b/iac-extensions/cloudformation/src/test/resources/cfn-lint/invalidPathTwo.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Filename": "doesNotExist.yaml"
+  },
+  {
+    "Filename": "a/b/doesNotExistToo.yaml"
+  },
+]


### PR DESCRIPTION
This is how the warning would look in the UI now:
![image](https://user-images.githubusercontent.com/64004037/225998507-e54eb8cc-ce4b-4094-94fa-f0c343cee338.png)
The part that was added in this PR is basically the `"Some file paths could not be resolved: doesNotExist.yaml, a/b/doesNotExistToo.yaml, ..."` to help the user identify the problem. 

Happy to give more context to the change if needed. 

Not sure why the SonarCloud bot is not commenting on this PR anymore. The analysis is green though: https://github.com/SonarSource/sonar-iac/pull/616/checks?check_run_id=12089634838