### PR TITLE
Set released sonarlint-core version for integration test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>
     <version.sonar>9.3.0.51899</version.sonar>
     <version.sonar.api>9.13.0.360</version.sonar.api>
-    <version.sonar.lint>8.16.0.66070</version.sonar.lint>
+    <version.sonar.lint>8.16.0.67686</version.sonar.lint>
     <version.analyzer.commons>1.24.0.965</version.analyzer.commons>
     <version.orchestrator>3.40.0.183</version.orchestrator>
     <version.sslr>1.24.0.633</version.sslr>


### PR DESCRIPTION
As we set an unreleased version we now fail to build the plugin. After 2 weeks the unreleased artifact will be removed. This will not affect the released version of sonar-iac but to have nightly builds of sonar-iac we have to set the used version to a released one which will not be deleted. 