### PR TITLE
SONARIAC-840 Convert JSON to Minimal ARM AST Model: Improve Property to support array and object

### DIFF
--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/parser/ArmParser.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/parser/ArmParser.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
-import org.sonar.api.batch.fs.TextPointer;
 import org.sonar.api.internal.apachecommons.lang.StringUtils;
 import org.sonar.api.utils.log.Logger;
 import org.sonar.api.utils.log.Loggers;
@@ -293,10 +292,8 @@ public class ArmParser implements TreeParser<ArmTree> {
 
     if (properties.containsKey("copy")) {
       ObjectExpression copy = toObjectExpression(properties.remove("copy").value());
-      if (copy != null) {
-        copyCount = convertToSimpleProperty(copy.getPropertyByName("count"));
-        copyInput = convertToSimpleProperty(copy.getPropertyByName("input"));
-      }
+      copyCount = convertToSimpleProperty(copy.getPropertyByName("count"));
+      copyInput = convertToSimpleProperty(copy.getPropertyByName("input"));
     }
 
     for (Map.Entry<String, Property> unexpectedProperty : properties.entrySet()) {
@@ -324,10 +321,6 @@ public class ArmParser implements TreeParser<ArmTree> {
 
   private static Map<String, Property> extractProperties(MappingTree tree) {
     return convertToObjectExpression(tree).getMapRepresentation();
-  }
-
-  private static Property convertTupleToProperty(TupleTree tuple) {
-    return new PropertyImpl(convertToIdentifier(tuple.key()), convertToPropertyValue(tuple.value()));
   }
 
   private static SimpleProperty convertTupleToSimpleProperty(TupleTree tuple) {
@@ -410,11 +403,7 @@ public class ArmParser implements TreeParser<ArmTree> {
     return new SimplePropertyImpl(property.key(), (Expression) property.value());
   }
 
-  @CheckForNull
-  private ObjectExpression toObjectExpression(@Nullable PropertyValue propertyValue) {
-    if (propertyValue == null) {
-      return null;
-    }
+  private ObjectExpression toObjectExpression(PropertyValue propertyValue) {
     if (!propertyValue.is(ArmTree.Kind.OBJECT_EXPRESSION)) {
       throw new ParseException("toObjectExpression: Expecting ObjectExpression, got " + propertyValue.getClass().getSimpleName() + " instead at " +
         buildLocation(propertyValue.textRange()), new BasicTextPointer(propertyValue.textRange()), null);

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ArmTree.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ArmTree.java
@@ -20,6 +20,7 @@
 package org.sonar.iac.arm.tree.api;
 
 import javax.annotation.CheckForNull;
+import org.sonar.iac.arm.tree.impl.json.PropertyImpl;
 import org.sonar.iac.common.api.tree.Tree;
 import org.sonar.sslr.grammar.GrammarRuleKey;
 
@@ -40,7 +41,10 @@ public interface ArmTree extends Tree {
     PARAMETER_DECLARATION(ParameterDeclaration.class),
     EXPRESSION(Expression.class),
     IDENTIFIER(Identifier.class),
-    OUTPUT_DECLARATION(OutputDeclaration.class);
+    OUTPUT_DECLARATION(OutputDeclaration.class),
+    PROPERTY(PropertyImpl.class),
+    ARRAY_EXPRESSION(ArrayExpression.class),
+    OBJECT_EXPRESSION(ObjectExpression.class);
 
     private final Class<? extends ArmTree> associatedInterface;
 

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ArrayExpression.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ArrayExpression.java
@@ -1,0 +1,7 @@
+package org.sonar.iac.arm.tree.api;
+
+import java.util.List;
+
+public interface ArrayExpression extends ArmTree, PropertyValue {
+  List<PropertyValue> values();
+}

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ArrayExpression.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ArrayExpression.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.iac.arm.tree.api;
 
 import java.util.List;

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ArrayExpression.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ArrayExpression.java
@@ -21,6 +21,6 @@ package org.sonar.iac.arm.tree.api;
 
 import java.util.List;
 
-public interface ArrayExpression extends ArmTree, PropertyValue {
+public interface ArrayExpression extends PropertyValue {
   List<PropertyValue> values();
 }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/Expression.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/Expression.java
@@ -19,6 +19,6 @@
  */
 package org.sonar.iac.arm.tree.api;
 
-public interface Expression extends ArmTree, PropertyValue {
+public interface Expression extends PropertyValue {
   String value();
 }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/Expression.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/Expression.java
@@ -19,6 +19,6 @@
  */
 package org.sonar.iac.arm.tree.api;
 
-public interface Expression extends ArmTree {
+public interface Expression extends ArmTree, PropertyValue {
   String value();
 }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ObjectExpression.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ObjectExpression.java
@@ -22,7 +22,7 @@ package org.sonar.iac.arm.tree.api;
 import java.util.List;
 import java.util.Map;
 
-public interface ObjectExpression extends ArmTree, PropertyValue {
+public interface ObjectExpression extends PropertyValue {
 
   List<Property> properties();
 

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ObjectExpression.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ObjectExpression.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.iac.arm.tree.api;
 
 import java.util.List;
@@ -8,4 +27,6 @@ public interface ObjectExpression extends ArmTree, PropertyValue {
   List<Property> properties();
 
   Map<String, Property> getMapRepresentation();
+
+  Property getPropertyByName(String propertyName);
 }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ObjectExpression.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ObjectExpression.java
@@ -1,0 +1,11 @@
+package org.sonar.iac.arm.tree.api;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ObjectExpression extends ArmTree, PropertyValue {
+
+  List<Property> properties();
+
+  Map<String, Property> getMapRepresentation();
+}

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ObjectExpression.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/ObjectExpression.java
@@ -21,6 +21,7 @@ package org.sonar.iac.arm.tree.api;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.CheckForNull;
 
 public interface ObjectExpression extends PropertyValue {
 
@@ -28,5 +29,6 @@ public interface ObjectExpression extends PropertyValue {
 
   Map<String, Property> getMapRepresentation();
 
+  @CheckForNull
   Property getPropertyByName(String propertyName);
 }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/Property.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/Property.java
@@ -21,8 +21,8 @@ package org.sonar.iac.arm.tree.api;
 
 import org.sonar.iac.common.api.tree.PropertyTree;
 
-public interface Property extends PropertyTree {
+public interface Property extends PropertyTree, PropertyValue {
   Identifier key();
 
-  Expression value();
+  PropertyValue value();
 }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/PropertyValue.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/PropertyValue.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.iac.arm.tree.api;
 
 public interface PropertyValue extends ArmTree {

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/PropertyValue.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/PropertyValue.java
@@ -1,0 +1,4 @@
+package org.sonar.iac.arm.tree.api;
+
+public interface PropertyValue extends ArmTree {
+}

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/SimpleProperty.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/SimpleProperty.java
@@ -1,0 +1,9 @@
+package org.sonar.iac.arm.tree.api;
+
+import org.sonar.iac.common.api.tree.PropertyTree;
+
+public interface SimpleProperty extends PropertyTree {
+  Identifier key();
+
+  Expression value();
+}

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/SimpleProperty.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/SimpleProperty.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.iac.arm.tree.api;
 
 import org.sonar.iac.common.api.tree.PropertyTree;

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ArmHelper.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ArmHelper.java
@@ -1,0 +1,28 @@
+package org.sonar.iac.arm.tree.impl.json;
+
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+import org.sonar.iac.arm.tree.api.Expression;
+import org.sonar.iac.arm.tree.api.SimpleProperty;
+import org.sonar.iac.common.api.tree.Tree;
+
+public class ArmHelper {
+
+  private ArmHelper() {}
+
+  public static void addChildrenIfPresent(List<Tree> children, @Nullable SimpleProperty property) {
+    if (property != null) {
+      children.add(property.key());
+      children.add(property.value());
+    }
+  }
+
+  @CheckForNull
+  public static Expression propertyValue(@Nullable SimpleProperty property) {
+    return Optional.ofNullable(property)
+      .map(SimpleProperty::value)
+      .orElse(null);
+  }
+}

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ArmHelper.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ArmHelper.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.iac.arm.tree.impl.json;
 
 import java.util.List;
@@ -10,7 +29,8 @@ import org.sonar.iac.common.api.tree.Tree;
 
 public class ArmHelper {
 
-  private ArmHelper() {}
+  private ArmHelper() {
+  }
 
   public static void addChildrenIfPresent(List<Tree> children, @Nullable SimpleProperty property) {
     if (property != null) {

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ArrayExpressionImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ArrayExpressionImpl.java
@@ -1,0 +1,31 @@
+package org.sonar.iac.arm.tree.impl.json;
+
+import java.util.Collections;
+import java.util.List;
+import org.sonar.iac.arm.tree.api.ArrayExpression;
+import org.sonar.iac.arm.tree.api.PropertyValue;
+import org.sonar.iac.arm.tree.impl.AbstractArmTreeImpl;
+import org.sonar.iac.common.api.tree.Tree;
+
+public class ArrayExpressionImpl extends AbstractArmTreeImpl implements ArrayExpression {
+  private final List<PropertyValue> values;
+
+  public ArrayExpressionImpl(List<PropertyValue> values) {
+    this.values = values;
+  }
+
+  @Override
+  public List<Tree> children() {
+    return Collections.unmodifiableList(values);
+  }
+
+  @Override
+  public Kind getKind() {
+    return Kind.ARRAY_EXPRESSION;
+  }
+
+  @Override
+  public List<PropertyValue> values() {
+    return values;
+  }
+}

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ArrayExpressionImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ArrayExpressionImpl.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.iac.arm.tree.impl.json;
 
 import java.util.Collections;
@@ -6,12 +25,21 @@ import org.sonar.iac.arm.tree.api.ArrayExpression;
 import org.sonar.iac.arm.tree.api.PropertyValue;
 import org.sonar.iac.arm.tree.impl.AbstractArmTreeImpl;
 import org.sonar.iac.common.api.tree.Tree;
+import org.sonar.iac.common.api.tree.impl.TextRange;
+import org.sonar.iac.common.yaml.tree.YamlTreeMetadata;
 
 public class ArrayExpressionImpl extends AbstractArmTreeImpl implements ArrayExpression {
   private final List<PropertyValue> values;
+  private final YamlTreeMetadata metadata;
 
-  public ArrayExpressionImpl(List<PropertyValue> values) {
+  public ArrayExpressionImpl(YamlTreeMetadata metadata, List<PropertyValue> values) {
+    this.metadata = metadata;
     this.values = values;
+  }
+
+  @Override
+  public TextRange textRange() {
+    return metadata.textRange();
   }
 
   @Override

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ObjectExpressionImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ObjectExpressionImpl.java
@@ -1,0 +1,50 @@
+package org.sonar.iac.arm.tree.impl.json;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.sonar.iac.arm.tree.api.ObjectExpression;
+import org.sonar.iac.arm.tree.api.Property;
+import org.sonar.iac.arm.tree.impl.AbstractArmTreeImpl;
+import org.sonar.iac.common.api.tree.Tree;
+
+public class ObjectExpressionImpl extends AbstractArmTreeImpl implements ObjectExpression {
+
+  private final List<Property> properties;
+
+  public ObjectExpressionImpl(List<Property> properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public List<Property> properties() {
+    return Collections.unmodifiableList(properties);
+  }
+
+  @Override
+  public Map<String, Property> getMapRepresentation() {
+    Map<String, Property> propertiesByIdentifier = new HashMap<>();
+    properties.forEach(property -> {
+      String key = property.key().value();
+      propertiesByIdentifier.put(key, property);
+    });
+    return propertiesByIdentifier;
+  }
+
+  @Override
+  public List<Tree> children() {
+    List<Tree> children = new ArrayList<>();
+    properties.forEach(property -> {
+      children.add(property.key());
+      children.add(property.value());
+    });
+    return children;
+  }
+
+  @Override
+  public Kind getKind() {
+    return Kind.OBJECT_EXPRESSION;
+  }
+}

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ObjectExpressionImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ObjectExpressionImpl.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.CheckForNull;
 import org.sonar.iac.arm.tree.api.ObjectExpression;
 import org.sonar.iac.arm.tree.api.Property;
 import org.sonar.iac.arm.tree.impl.AbstractArmTreeImpl;
@@ -56,6 +57,7 @@ public class ObjectExpressionImpl extends AbstractArmTreeImpl implements ObjectE
   }
 
   @Override
+  @CheckForNull
   public Property getPropertyByName(String propertyName) {
     return getMapRepresentation().get(propertyName);
   }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ObjectExpressionImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ObjectExpressionImpl.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.iac.arm.tree.impl.json;
 
 import java.util.ArrayList;
@@ -13,6 +32,7 @@ import org.sonar.iac.common.api.tree.Tree;
 public class ObjectExpressionImpl extends AbstractArmTreeImpl implements ObjectExpression {
 
   private final List<Property> properties;
+  private Map<String, Property> mapRepresentation = null;
 
   public ObjectExpressionImpl(List<Property> properties) {
     this.properties = properties;
@@ -25,12 +45,19 @@ public class ObjectExpressionImpl extends AbstractArmTreeImpl implements ObjectE
 
   @Override
   public Map<String, Property> getMapRepresentation() {
-    Map<String, Property> propertiesByIdentifier = new HashMap<>();
-    properties.forEach(property -> {
-      String key = property.key().value();
-      propertiesByIdentifier.put(key, property);
-    });
-    return propertiesByIdentifier;
+    if (mapRepresentation == null) {
+      mapRepresentation = new HashMap<>();
+      properties.forEach(property -> {
+        String key = property.key().value();
+        mapRepresentation.put(key, property);
+      });
+    }
+    return mapRepresentation;
+  }
+
+  @Override
+  public Property getPropertyByName(String propertyName) {
+    return getMapRepresentation().get(propertyName);
   }
 
   @Override

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/OutputDeclarationImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/OutputDeclarationImpl.java
@@ -21,26 +21,29 @@ package org.sonar.iac.arm.tree.impl.json;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.iac.arm.tree.api.Expression;
 import org.sonar.iac.arm.tree.api.Identifier;
 import org.sonar.iac.arm.tree.api.OutputDeclaration;
-import org.sonar.iac.arm.tree.api.Property;
+import org.sonar.iac.arm.tree.api.SimpleProperty;
 import org.sonar.iac.arm.tree.impl.AbstractArmTreeImpl;
 import org.sonar.iac.common.api.tree.Tree;
+
+import static org.sonar.iac.arm.tree.impl.json.ArmHelper.addChildrenIfPresent;
+import static org.sonar.iac.arm.tree.impl.json.ArmHelper.propertyValue;
 
 public class OutputDeclarationImpl extends AbstractArmTreeImpl implements OutputDeclaration {
 
   private final Identifier name;
-  private final Property type;
-  private final Property condition;
-  private final Property copyCount;
-  private final Property copyInput;
-  private final Property value;
+  private final SimpleProperty type;
+  private final SimpleProperty condition;
+  private final SimpleProperty copyCount;
+  private final SimpleProperty copyInput;
+  private final SimpleProperty value;
 
-  public OutputDeclarationImpl(Identifier name, Property type, @Nullable Property condition, @Nullable Property copyCount, @Nullable Property copyInput, @Nullable Property value) {
+  public OutputDeclarationImpl(Identifier name, SimpleProperty type, @Nullable SimpleProperty condition, @Nullable SimpleProperty copyCount,
+    @Nullable SimpleProperty copyInput, @Nullable SimpleProperty value) {
     this.name = name;
     this.type = type;
     this.condition = condition;
@@ -83,13 +86,6 @@ public class OutputDeclarationImpl extends AbstractArmTreeImpl implements Output
     return propertyValue(value);
   }
 
-  @CheckForNull
-  private static Expression propertyValue(@Nullable Property property) {
-    return Optional.ofNullable(property)
-      .map(Property::value)
-      .orElse(null);
-  }
-
   @Override
   public List<Tree> children() {
     List<Tree> children = new ArrayList<>();
@@ -101,13 +97,6 @@ public class OutputDeclarationImpl extends AbstractArmTreeImpl implements Output
     addChildrenIfPresent(children, copyCount);
     addChildrenIfPresent(children, copyInput);
     return children;
-  }
-
-  private static void addChildrenIfPresent(List<Tree> children, @Nullable Property property) {
-    if (property != null) {
-      children.add(property.key());
-      children.add(property.value());
-    }
   }
 
   @Override

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ParameterDeclarationImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ParameterDeclarationImpl.java
@@ -27,7 +27,6 @@ import org.sonar.iac.arm.tree.api.Expression;
 import org.sonar.iac.arm.tree.api.Identifier;
 import org.sonar.iac.arm.tree.api.ParameterDeclaration;
 import org.sonar.iac.arm.tree.api.ParameterType;
-import org.sonar.iac.arm.tree.api.Property;
 import org.sonar.iac.arm.tree.api.SimpleProperty;
 import org.sonar.iac.arm.tree.impl.AbstractArmTreeImpl;
 import org.sonar.iac.common.api.tree.Tree;

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ParameterDeclarationImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ParameterDeclarationImpl.java
@@ -28,33 +28,36 @@ import org.sonar.iac.arm.tree.api.Identifier;
 import org.sonar.iac.arm.tree.api.ParameterDeclaration;
 import org.sonar.iac.arm.tree.api.ParameterType;
 import org.sonar.iac.arm.tree.api.Property;
+import org.sonar.iac.arm.tree.api.SimpleProperty;
 import org.sonar.iac.arm.tree.impl.AbstractArmTreeImpl;
 import org.sonar.iac.common.api.tree.Tree;
+
+import static org.sonar.iac.arm.tree.impl.json.ArmHelper.addChildrenIfPresent;
 
 public class ParameterDeclarationImpl extends AbstractArmTreeImpl implements ParameterDeclaration {
 
   private final Identifier identifier;
-  private final Property type;
-  private final Property defaultValue;
+  private final SimpleProperty type;
+  private final SimpleProperty defaultValue;
   private final List<Expression> allowedValues;
-  private final Property description;
-  private final Property minValue;
-  private final Property maxValue;
-  private final Property minLength;
-  private final Property maxLength;
+  private final SimpleProperty description;
+  private final SimpleProperty minValue;
+  private final SimpleProperty maxValue;
+  private final SimpleProperty minLength;
+  private final SimpleProperty maxLength;
 
   // Methods should not have too many parameters
   @SuppressWarnings("java:S107")
   public ParameterDeclarationImpl(
     Identifier identifier,
-    Property type,
-    @Nullable Property defaultValue,
+    SimpleProperty type,
+    @Nullable SimpleProperty defaultValue,
     List<Expression> allowedValues,
-    @Nullable Property description,
-    @Nullable Property minValue,
-    @Nullable Property maxValue,
-    @Nullable Property minLength,
-    @Nullable Property maxLength) {
+    @Nullable SimpleProperty description,
+    @Nullable SimpleProperty minValue,
+    @Nullable SimpleProperty maxValue,
+    @Nullable SimpleProperty minLength,
+    @Nullable SimpleProperty maxLength) {
 
     this.identifier = identifier;
     this.type = type;
@@ -155,12 +158,5 @@ public class ParameterDeclarationImpl extends AbstractArmTreeImpl implements Par
   @Override
   public Kind getKind() {
     return Kind.PARAMETER_DECLARATION;
-  }
-
-  private static void addChildrenIfPresent(List<Tree> children, @Nullable Property property) {
-    if (property != null) {
-      children.add(property.key());
-      children.add(property.value());
-    }
   }
 }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/PropertyImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/PropertyImpl.java
@@ -20,18 +20,23 @@
 package org.sonar.iac.arm.tree.impl.json;
 
 import java.util.List;
+import javax.annotation.CheckForNull;
+import org.sonar.iac.arm.tree.api.ArmTree;
 import org.sonar.iac.arm.tree.api.Expression;
 import org.sonar.iac.arm.tree.api.Identifier;
 import org.sonar.iac.arm.tree.api.Property;
+import org.sonar.iac.arm.tree.api.PropertyValue;
+import org.sonar.iac.arm.tree.impl.AbstractArmTreeImpl;
+import org.sonar.iac.common.api.tree.Tree;
 import org.sonar.iac.common.api.tree.impl.TextRange;
 import org.sonar.iac.common.api.tree.impl.TextRanges;
 
-public class PropertyImpl implements Property {
+public class PropertyImpl extends AbstractArmTreeImpl implements Property {
 
   private final Identifier key;
-  private final Expression value;
+  private final PropertyValue value;
 
-  public PropertyImpl(Identifier key, Expression value) {
+  public PropertyImpl(Identifier key, PropertyValue value) {
     this.key = key;
     this.value = value;
   }
@@ -42,12 +47,22 @@ public class PropertyImpl implements Property {
   }
 
   @Override
-  public Expression value() {
+  public PropertyValue value() {
     return value;
   }
 
   @Override
   public TextRange textRange() {
     return TextRanges.merge(List.of(key.textRange(), value.textRange()));
+  }
+
+  @Override
+  public List<Tree> children() {
+    return List.of(key, value);
+  }
+
+  @Override
+  public Kind getKind() {
+    return Kind.PROPERTY;
   }
 }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/PropertyImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/PropertyImpl.java
@@ -20,9 +20,6 @@
 package org.sonar.iac.arm.tree.impl.json;
 
 import java.util.List;
-import javax.annotation.CheckForNull;
-import org.sonar.iac.arm.tree.api.ArmTree;
-import org.sonar.iac.arm.tree.api.Expression;
 import org.sonar.iac.arm.tree.api.Identifier;
 import org.sonar.iac.arm.tree.api.Property;
 import org.sonar.iac.arm.tree.api.PropertyValue;

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ResourceDeclarationImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ResourceDeclarationImpl.java
@@ -28,8 +28,6 @@ import org.sonar.iac.arm.tree.api.SimpleProperty;
 import org.sonar.iac.arm.tree.impl.AbstractArmTreeImpl;
 import org.sonar.iac.common.api.tree.Tree;
 
-import static org.sonar.iac.arm.tree.impl.json.ArmHelper.propertyValue;
-
 public class ResourceDeclarationImpl extends AbstractArmTreeImpl implements ResourceDeclaration {
 
   private final SimpleProperty name;

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ResourceDeclarationImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/ResourceDeclarationImpl.java
@@ -24,17 +24,20 @@ import java.util.List;
 import org.sonar.iac.arm.tree.api.Expression;
 import org.sonar.iac.arm.tree.api.Property;
 import org.sonar.iac.arm.tree.api.ResourceDeclaration;
+import org.sonar.iac.arm.tree.api.SimpleProperty;
 import org.sonar.iac.arm.tree.impl.AbstractArmTreeImpl;
 import org.sonar.iac.common.api.tree.Tree;
 
+import static org.sonar.iac.arm.tree.impl.json.ArmHelper.propertyValue;
+
 public class ResourceDeclarationImpl extends AbstractArmTreeImpl implements ResourceDeclaration {
 
-  private final Property name;
-  private final Property version;
-  private final Property type;
+  private final SimpleProperty name;
+  private final SimpleProperty version;
+  private final SimpleProperty type;
   private final List<Property> properties;
 
-  public ResourceDeclarationImpl(Property name, Property version, Property type, List<Property> properties) {
+  public ResourceDeclarationImpl(SimpleProperty name, SimpleProperty version, SimpleProperty type, List<Property> properties) {
     this.name = name;
     this.version = version;
     this.type = type;

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/SimplePropertyImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/SimplePropertyImpl.java
@@ -1,0 +1,34 @@
+package org.sonar.iac.arm.tree.impl.json;
+
+import java.util.List;
+import org.sonar.iac.arm.tree.api.Expression;
+import org.sonar.iac.arm.tree.api.Identifier;
+import org.sonar.iac.arm.tree.api.SimpleProperty;
+import org.sonar.iac.common.api.tree.impl.TextRange;
+import org.sonar.iac.common.api.tree.impl.TextRanges;
+
+public class SimplePropertyImpl implements SimpleProperty {
+
+  private final Identifier key;
+  private final Expression value;
+
+  public SimplePropertyImpl(Identifier key, Expression value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  @Override
+  public Identifier key() {
+    return key;
+  }
+
+  @Override
+  public Expression value() {
+    return value;
+  }
+
+  @Override
+  public TextRange textRange() {
+    return TextRanges.merge(List.of(key.textRange(), value.textRange()));
+  }
+}

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/SimplePropertyImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/SimplePropertyImpl.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.iac.arm.tree.impl.json;
 
 import java.util.List;

--- a/iac-extensions/arm/src/test/java/org/sonar/iac/arm/parser/json/OutputDeclarationTest.java
+++ b/iac-extensions/arm/src/test/java/org/sonar/iac/arm/parser/json/OutputDeclarationTest.java
@@ -58,8 +58,7 @@ class OutputDeclarationTest {
       "      \"type\": \"my type\",",
       "      \"condition\": \"my condition\",",
       "      \"copy\": {",
-      "        \"count\": \"countValue\",",
-      "        \"input\": \"inputValue\"",
+      "        \"count\": \"countValue\"",
       "      },",
       "      \"value\": \"my output value\"",
       "    }",
@@ -75,9 +74,9 @@ class OutputDeclarationTest {
     assertThat(outputDeclaration.type().value()).isEqualTo("my type");
     assertThat(outputDeclaration.condition().value()).isEqualTo("my condition");
     assertThat(outputDeclaration.copyCount().value()).isEqualTo("countValue");
-    assertThat(outputDeclaration.copyInput().value()).isEqualTo("inputValue");
+    assertThat(outputDeclaration.copyInput()).isNull();
     assertThat(outputDeclaration.value().value()).isEqualTo("my output value");
-    assertThat(outputDeclaration.textRange()).hasRange(3, 4, 10, 32);
+    assertThat(outputDeclaration.textRange()).hasRange(3, 4, 9, 32);
 
     assertThat(outputDeclaration.name())
       .is(IDENTIFIER)
@@ -85,19 +84,17 @@ class OutputDeclarationTest {
       .hasRange(3, 4, 3, 19);
 
     List<Tree> children = outputDeclaration.children();
-    assertThat(children).hasSize(11);
+    assertThat(children).hasSize(9);
 
     assertThat((ArmTree) children.get(0)).is(IDENTIFIER).has("value", "myOutputValue").hasRange(3, 4, 3, 19);
     assertThat((ArmTree) children.get(1)).is(IDENTIFIER).has("value", "type").hasRange(4, 6, 4, 12);
     assertThat((ArmTree) children.get(2)).is(EXPRESSION).has("value", "my type").hasRange(4, 14, 4, 23);
     assertThat((ArmTree) children.get(3)).is(IDENTIFIER).has("value", "condition").hasRange(5, 6, 5, 17);
     assertThat((ArmTree) children.get(4)).is(EXPRESSION).has("value", "my condition").hasRange(5, 19, 5, 33);
-    assertThat((ArmTree) children.get(5)).is(IDENTIFIER).has("value", "value").hasRange(10, 6, 10, 13);
-    assertThat((ArmTree) children.get(6)).is(EXPRESSION).has("value", "my output value").hasRange(10, 15, 10, 32);
+    assertThat((ArmTree) children.get(5)).is(IDENTIFIER).has("value", "value").hasRange(9, 6, 9, 13);
+    assertThat((ArmTree) children.get(6)).is(EXPRESSION).has("value", "my output value").hasRange(9, 15, 9, 32);
     assertThat((ArmTree) children.get(7)).is(IDENTIFIER).has("value", "count").hasRange(7, 8, 7, 15);
     assertThat((ArmTree) children.get(8)).is(EXPRESSION).has("value", "countValue").hasRange(7, 17, 7, 29);
-    assertThat((ArmTree) children.get(9)).is(IDENTIFIER).has("value", "input").hasRange(8, 8, 8, 15);
-    assertThat((ArmTree) children.get(10)).is(EXPRESSION).has("value", "inputValue").hasRange(8, 17, 8, 29);
   }
 
   @Test

--- a/iac-extensions/arm/src/test/java/org/sonar/iac/arm/parser/json/OutputDeclarationTest.java
+++ b/iac-extensions/arm/src/test/java/org/sonar/iac/arm/parser/json/OutputDeclarationTest.java
@@ -278,4 +278,40 @@ class OutputDeclarationTest {
     assertThat(parseException.getPosition().line()).isEqualTo(3);
     assertThat(parseException.getPosition().lineOffset()).isEqualTo(21);
   }
+
+  @Test
+  void shouldFailOnCopyUnexpectedFormat() {
+    String code = code("{",
+      "  \"outputs\": {",
+      "    \"myOutputValue\": {",
+      "      \"type\": \"my type\",",
+      "      \"copy\": []",
+      "    }",
+      "  }",
+      "}");
+    ParseException parseException = catchThrowableOfType(() -> parser.parse(code, null), ParseException.class);
+    assertThat(parseException).hasMessage("toObjectExpression: Expecting ObjectExpression, got ArrayExpressionImpl instead at 5:14");
+    assertThat(parseException.getDetails()).isNull();
+    assertThat(parseException.getPosition().line()).isEqualTo(5);
+    assertThat(parseException.getPosition().lineOffset()).isEqualTo(14);
+  }
+
+  @Test
+  void shouldFailOnCopyInternalUnexpectedFormat() {
+    String code = code("{",
+      "  \"outputs\": {",
+      "    \"myOutputValue\": {",
+      "      \"type\": \"my type\",",
+      "      \"copy\": {",
+      "        \"count\": []",
+      "      }",
+      "    }",
+      "  }",
+      "}");
+    ParseException parseException = catchThrowableOfType(() -> parser.parse(code, null), ParseException.class);
+    assertThat(parseException).hasMessage("convertToSimpleProperty: Expecting Expression in property value, got ArrayExpressionImpl instead at 6:17");
+    assertThat(parseException.getDetails()).isNull();
+    assertThat(parseException.getPosition().line()).isEqualTo(6);
+    assertThat(parseException.getPosition().lineOffset()).isEqualTo(17);
+  }
 }

--- a/iac-extensions/arm/src/test/java/org/sonar/iac/arm/parser/json/OutputDeclarationTest.java
+++ b/iac-extensions/arm/src/test/java/org/sonar/iac/arm/parser/json/OutputDeclarationTest.java
@@ -156,7 +156,7 @@ class OutputDeclarationTest {
       "  }",
       "}");
     ParseException parseException = catchThrowableOfType(() -> parser.parse(code, null), ParseException.class);
-    assertThat(parseException).hasMessage("Missing required field [\"type\"] at 3:4");
+    assertThat(parseException).hasMessage("Missing mandatory attribute 'type' at 3:4");
     assertThat(parseException.getDetails()).isNull();
     assertThat(parseException.getPosition().line()).isEqualTo(3);
     assertThat(parseException.getPosition().lineOffset()).isEqualTo(4);

--- a/iac-extensions/arm/src/test/java/org/sonar/iac/arm/parser/json/OutputDeclarationTest.java
+++ b/iac-extensions/arm/src/test/java/org/sonar/iac/arm/parser/json/OutputDeclarationTest.java
@@ -256,7 +256,7 @@ class OutputDeclarationTest {
       "  }",
       "}");
     ParseException parseException = catchThrowableOfType(() -> parser.parse(code, null), ParseException.class);
-    assertThat(parseException).hasMessage("Unsupported type for extractProperties, expected MappingTree or ScalarTree, got 'SequenceTreeImpl'");
+    assertThat(parseException).hasMessage("convertToSimpleProperty: Expecting Expression in property value, got ArrayExpressionImpl instead at 5:15");
     assertThat(parseException.getDetails()).isNull();
     assertThat(parseException.getPosition().line()).isEqualTo(5);
     assertThat(parseException.getPosition().lineOffset()).isEqualTo(15);

--- a/iac-extensions/arm/src/test/java/org/sonar/iac/arm/parser/json/ResourceDeclarationTest.java
+++ b/iac-extensions/arm/src/test/java/org/sonar/iac/arm/parser/json/ResourceDeclarationTest.java
@@ -87,8 +87,9 @@ class ResourceDeclarationTest {
     assertThat((ArmTree) children.get(2)).is(IDENTIFIER).has("value", "apiVersion").hasRange(5, 6, 5, 18);
     assertThat((ArmTree) children.get(3)).is(EXPRESSION).has("value", "2022-12-29").hasRange(5, 20, 5, 32);
     assertThat((ArmTree) children.get(4)).is(IDENTIFIER).has("value", "type").hasRange(4, 6, 4, 12);
-    assertThat((ArmTree) children.get(5)).is(EXPRESSION).has("value", "Microsoft.Kusto/clusters").hasRange(4, 14, 4, 40);;
+    assertThat((ArmTree) children.get(5)).is(EXPRESSION).has("value", "Microsoft.Kusto/clusters").hasRange(4, 14, 4, 40);
   }
+
   @Test
   void shouldParseResourceWithExtraProperties() {
     String code = code("{",

--- a/iac-extensions/arm/src/test/java/org/sonar/iac/arm/parser/json/ResourceDeclarationTest.java
+++ b/iac-extensions/arm/src/test/java/org/sonar/iac/arm/parser/json/ResourceDeclarationTest.java
@@ -20,11 +20,13 @@
 package org.sonar.iac.arm.parser.json;
 
 import java.util.List;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.sonar.iac.arm.parser.ArmParser;
 import org.sonar.iac.arm.tree.api.ArmTree;
+import org.sonar.iac.arm.tree.api.Expression;
 import org.sonar.iac.arm.tree.api.File;
 import org.sonar.iac.arm.tree.api.Property;
 import org.sonar.iac.arm.tree.api.ResourceDeclaration;
@@ -74,7 +76,8 @@ class ResourceDeclarationTest {
     List<Property> properties = resourceDeclaration.properties();
     assertThat(properties).hasSize(1);
     assertThat(properties.get(0).key().value()).isEqualTo("location");
-    assertThat(properties.get(0).value().value()).isEqualTo("random location");
+    assertThat(properties.get(0).value().is(EXPRESSION)).isTrue();
+    assertThat(((Expression) properties.get(0).value()).value()).isEqualTo("random location");
     IacCommonAssertions.assertThat(properties.get(0).textRange()).hasRange(7, 6, 7, 35);
 
     List<Tree> children = resourceDeclaration.children();
@@ -104,7 +107,7 @@ class ResourceDeclarationTest {
       "}");
     assertThatThrownBy(() -> parser.parse(code, null))
       .isInstanceOf(ParseException.class)
-      .hasMessage("Unsupported type for extractProperties, expected MappingTree or ScalarTree, got 'SequenceTreeImpl'");
+      .hasMessage("convertToSimpleProperty: Expecting Expression in property value, got ArrayExpressionImpl instead at 6:14");
   }
 
   @ParameterizedTest
@@ -162,7 +165,8 @@ class ResourceDeclarationTest {
     assertThat(resourceDeclaration1.name().value()).isEqualTo("name1");
     assertThat(resourceDeclaration1.properties()).hasSize(1);
     assertThat(resourceDeclaration1.properties().get(0).key().value()).isEqualTo("property1");
-    assertThat(resourceDeclaration1.properties().get(0).value().value()).isEqualTo("value1");
+    assertThat(resourceDeclaration1.properties().get(0).value().is(EXPRESSION)).isTrue();
+    assertThat(((Expression) resourceDeclaration1.properties().get(0).value()).value()).isEqualTo("value1");
 
     ResourceDeclaration resourceDeclaration2 = (ResourceDeclaration) tree.statements().get(1);
     assertThat(resourceDeclaration2.type()).isEqualTo("type2");
@@ -170,6 +174,7 @@ class ResourceDeclarationTest {
     assertThat(resourceDeclaration2.name().value()).isEqualTo("name2");
     assertThat(resourceDeclaration2.properties()).hasSize(1);
     assertThat(resourceDeclaration2.properties().get(0).key().value()).isEqualTo("property2");
-    assertThat(resourceDeclaration2.properties().get(0).value().value()).isEqualTo("value2");
+    assertThat(resourceDeclaration2.properties().get(0).value().is(EXPRESSION)).isTrue();
+    assertThat(((Expression) resourceDeclaration2.properties().get(0).value()).value()).isEqualTo("value2");
   }
 }

--- a/iac-extensions/arm/src/test/java/org/sonar/iac/arm/parser/json/ResourceDeclarationTest.java
+++ b/iac-extensions/arm/src/test/java/org/sonar/iac/arm/parser/json/ResourceDeclarationTest.java
@@ -113,12 +113,12 @@ class ResourceDeclarationTest {
   @ParameterizedTest
   @CsvSource(delimiter = ';', value = {
     // " ", // surprisingly, this throw a different parseException, apparently a node cannot have empty content
-    "                                                    \"type\":\"myType\"; fields [\"apiVersion\", \"name\"]",
-    "                        \"apiVersion\":\"version\"                     ; fields [\"type\", \"name\"]",
-    "                        \"apiVersion\":\"version\", \"type\":\"myType\"; field [\"name\"]",
-    "\"name\":\"nameValue\"                                                 ; fields [\"type\", \"apiVersion\"]",
-    "\"name\":\"nameValue\",                             \"type\":\"myType\"; field [\"apiVersion\"]",
-    "\"name\":\"nameValue\", \"apiVersion\":\"version\"                     ; field [\"type\"]",
+    "                                                    \"type\":\"myType\"; apiVersion",
+    "                        \"apiVersion\":\"version\"                     ; type",
+    "                        \"apiVersion\":\"version\", \"type\":\"myType\"; name",
+    "\"name\":\"nameValue\"                                                 ; type",
+    "\"name\":\"nameValue\",                             \"type\":\"myType\"; apiVersion",
+    "\"name\":\"nameValue\", \"apiVersion\":\"version\"                     ; type",
   })
   void shouldThrowParseExceptionOnIncompleteResource(String attributes, String errorMessageComponents) {
     String code = code("{",
@@ -129,7 +129,7 @@ class ResourceDeclarationTest {
       "  ]",
       "}");
     ParseException parseException = catchThrowableOfType(() -> parser.parse(code, null), ParseException.class);
-    assertThat(parseException).hasMessage("Missing required " + errorMessageComponents + " at 3:4");
+    assertThat(parseException).hasMessage("Missing mandatory attribute '" + errorMessageComponents + "' at 3:4");
     assertThat(parseException.getDetails()).isNull();
     assertThat(parseException.getPosition().line()).isEqualTo(3);
     assertThat(parseException.getPosition().lineOffset()).isEqualTo(4);


### PR DESCRIPTION
Changed a bit the approach regarding `Property`:
- `Property` as it was has been renamed to `SimpleProperty`: the key is an `Identifier` and the value is always an `Expression`
- Created a `PropertyValue` interface, with three implementations:
  - `Expression`, to represent simple value such as `"string"` or `5`
  - `ArrayExpression`, to represent a typical array such as `["value1", "value2"]`, where each entry is a `PropertyValue` also
  - `ObjectExpression`, which is an object like `{"key":"value"}`, represented as a `List<Property>` and some methods to use it as a `Map`
- `Property` still has `Identifier` as a key, but the value is now a `PropertyValue`

Added some useful methods regarding those changes, like a way to extract and/or convert elements to `SimpleProperty`, which are mainly used in our convertors for `ResourceDeclaration`, `ParameterDeclaration` and `OutputDeclaration`.

I also removed the method `checkMandatoryObject` for several reasons:
- it was a bit hacky
- it obfuscated the code and raised FP on some check-null rules for both sonarlint and intellij
- it would parse the whole object and fail at the end, once it discovers that one property was missing

The new approach is to require specific properties and to fail fast / as soon as we detect they are missing.