### PR TITLE
SONARIAC-877 Add ArchUnit to avoid common mistakes

### DIFF
--- a/sonar-iac-plugin/src/test/java/org/sonar/iac/ArchUnitTest.java
+++ b/sonar-iac-plugin/src/test/java/org/sonar/iac/ArchUnitTest.java
@@ -45,9 +45,9 @@ public class ArchUnitTest {
       @Override
       public void check(JavaClass javaClass, ConditionEvents events) {
         boolean satisfied = javaClass.getConstructors().stream()
-          .anyMatch(constructor -> constructor.getModifiers().contains(JavaModifier.PUBLIC));
+          .allMatch(constructor -> constructor.getModifiers().contains(JavaModifier.PUBLIC));
         String message = javaClass.getDescription() + (satisfied ? " has" : " does not have")
-          + " a public constructor";
+          + " all public constructors";
         events.add(new SimpleConditionEvent(javaClass, satisfied, message));
       }
     });


### PR DESCRIPTION
Improve the check for public constructors in Sensors. Previously one public constructor was enough, now all constructors needs to be public.