### PR TITLE
SONARIAC-892 Build an ARM Domain Specific Language to simplify rule implementation (Property & Object symbol)

### DIFF
--- a/iac-common/src/test/java/org/sonar/iac/common/dsl/CommonPropertySymbolTest.java
+++ b/iac-common/src/test/java/org/sonar/iac/common/dsl/CommonPropertySymbolTest.java
@@ -1,0 +1,92 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.iac.common.dsl;
+
+import java.util.Collections;
+import java.util.function.Predicate;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.sonar.iac.common.api.checks.CheckContext;
+import org.sonar.iac.common.api.tree.PropertyTree;
+import org.sonar.iac.common.api.tree.TextTree;
+import org.sonar.iac.common.api.tree.Tree;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class CommonPropertySymbolTest {
+
+  final CheckContext ctx = mock(CheckContext.class);
+  final TestPropertyTree tree = mock(TestPropertyTree.class);
+
+  final TestPropertySymbol present = new TestPropertySymbol(ctx, tree, null);
+
+  final TestPropertySymbol absent = new TestPropertySymbol(ctx, null, null);
+
+  final Predicate<Tree> allwaysTrue = t -> true;
+
+  @Test
+  void reportIfOnPresentProperty() {
+    present.reportIf(allwaysTrue, "true");
+    present.reportIf(t -> false, "false");
+    verify(ctx, times(1)).reportIssue(tree, "true", Collections.emptyList());
+  }
+
+  @Test
+  void reportIfOnAbsentProperty() {
+    absent.reportIf(allwaysTrue, "message");
+    absent.reportIf(t -> false, "message");
+    verifyNoInteractions(ctx);
+  }
+
+  @Test
+  void isOnPresentProperty() {
+    assertThat(present.is(allwaysTrue)).isTrue();
+  }
+
+  @Test
+  void isOnAbsentProperty() {
+    assertThat(absent.is(allwaysTrue)).isTrue();
+  }
+
+  @Test
+  void asString() {
+    TextTree text = mock(TextTree.class);
+    when(text.value()).thenReturn("value");
+    when(tree.value()).thenReturn(text);
+    TestPropertySymbol symbol = new TestPropertySymbol(ctx, tree, null);
+    assertThat(symbol.asString()).isEqualTo("value");
+  }
+
+  private static class TestPropertySymbol extends CommonPropertySymbol<TestPropertySymbol, TestPropertyTree, Tree> {
+    TestPropertySymbol(CheckContext ctx, @Nullable TestPropertyTree tree, @Nullable Symbol<? extends Symbol<?, ?>, ? extends Tree> parent) {
+      super(ctx, tree, "test", parent);
+    }
+  }
+
+  interface TestPropertyTree extends PropertyTree, Tree {
+
+  }
+
+}

--- a/iac-common/src/test/java/org/sonar/iac/common/dsl/SymbolTest.java
+++ b/iac-common/src/test/java/org/sonar/iac/common/dsl/SymbolTest.java
@@ -1,0 +1,114 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.iac.common.dsl;
+
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+import org.sonar.iac.common.api.checks.CheckContext;
+import org.sonar.iac.common.api.checks.SecondaryLocation;
+import org.sonar.iac.common.api.tree.Tree;
+import org.sonar.iac.common.api.tree.impl.TextRange;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class SymbolTest {
+
+  final CheckContext ctx = mock(CheckContext.class);
+  final Tree tree = mock(Tree.class);
+
+  final Tree parentTree = mock(Tree.class);
+
+  final TestSymbol parent = new TestSymbol(ctx, parentTree, null);
+
+  final TestSymbol present = new TestSymbol(ctx, tree, parent);
+  final TestSymbol absent = new TestSymbol(ctx, null, parent);
+
+  @Test
+  void report() {
+    present.report("present");
+    absent.report("absent");
+
+    verify(ctx, times(1)).reportIssue(tree, "present", Collections.emptyList());
+  }
+
+  @Test
+  void reportWithSecondary() {
+    SecondaryLocation secondary = mock(SecondaryLocation.class);
+    present.report("message", secondary);
+    verify(ctx, times(1)).reportIssue(tree, "message", List.of(secondary));
+  }
+
+  @Test
+  void toSecondary() {
+    TextRange textRange = mock(TextRange.class);
+    when(tree.textRange()).thenReturn(textRange);
+
+    SecondaryLocation presentSecondary = present.toSecondary("secondary");
+
+    assertThat(presentSecondary).isNotNull();
+    assertThat(presentSecondary.message).isEqualTo("secondary");
+    assertThat(presentSecondary.textRange).isEqualTo(textRange);
+
+    assertThat(absent.toSecondary("secondary")).isNull();
+  }
+
+  @Test
+  void reportIfAbsent() {
+    present.reportIfAbsent("present");
+    absent.reportIfAbsent("absent");
+
+    verify(ctx, times(1)).reportIssue(parentTree, "absent", Collections.emptyList());
+  }
+
+  @Test
+  void reportIfAbsentWithoutParent() {
+    TestSymbol symbol = new TestSymbol(ctx, null, null);
+    symbol.reportIfAbsent("test");
+
+    verifyNoInteractions(ctx);
+  }
+
+  @Test
+  void isPresent() {
+    assertThat(present.isPresent()).isTrue();
+    assertThat(absent.isPresent()).isFalse();
+  }
+
+  @Test
+  void isAbsent() {
+    assertThat(present.isAbsent()).isFalse();
+    assertThat(absent.isAbsent()).isTrue();
+  }
+
+  static class TestSymbol extends Symbol<TestSymbol, Tree> {
+
+    protected TestSymbol(CheckContext ctx, @Nullable Tree tree, @Nullable Symbol<? extends Symbol<?, ?>, ? extends Tree> parent) {
+      super(ctx, tree, "test", parent);
+    }
+  }
+
+}

--- a/iac-common/src/test/java/org/sonar/iac/common/dsl/SymbolTest.java
+++ b/iac-common/src/test/java/org/sonar/iac/common/dsl/SymbolTest.java
@@ -30,6 +30,7 @@ import org.sonar.iac.common.api.tree.impl.TextRange;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -53,6 +54,7 @@ class SymbolTest {
     absent.report("absent");
 
     verify(ctx, times(1)).reportIssue(tree, "present", Collections.emptyList());
+    verify(ctx, never()).reportIssue(tree, "absent", Collections.emptyList());
   }
 
   @Test
@@ -82,6 +84,7 @@ class SymbolTest {
     absent.reportIfAbsent("absent");
 
     verify(ctx, times(1)).reportIssue(parentTree, "absent", Collections.emptyList());
+    verify(ctx, never()).reportIssue(parentTree, "present", Collections.emptyList());
   }
 
   @Test

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/symbols/MapSymbol.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/symbols/MapSymbol.java
@@ -1,0 +1,51 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.iac.arm.symbols;
+
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.sonar.iac.arm.tree.api.ObjectExpression;
+import org.sonar.iac.arm.tree.api.Property;
+import org.sonar.iac.common.api.checks.CheckContext;
+import org.sonar.iac.common.api.tree.HasProperties;
+import org.sonar.iac.common.api.tree.Tree;
+import org.sonar.iac.common.checks.PropertyUtils;
+import org.sonar.iac.common.dsl.Symbol;
+
+public abstract class MapSymbol<S extends MapSymbol<S, T>, T extends HasProperties & Tree> extends Symbol<MapSymbol<S, T>, T> {
+
+  protected MapSymbol(CheckContext ctx, @Nullable T tree, @Nullable String name, @Nullable MapSymbol<?, ?> parent) {
+    super(ctx, tree, name, parent);
+  }
+
+  public PropertySymbol property(String name) {
+    return Optional.ofNullable(tree)
+      .flatMap(tree -> PropertyUtils.get(tree, name, Property.class))
+      .map(property -> PropertySymbol.fromPresent(ctx, property, this))
+      .orElse(PropertySymbol.fromAbsent(ctx, name, this));
+  }
+
+  public ObjectSymbol object(String name) {
+    return Optional.ofNullable(tree)
+      .flatMap(tree -> PropertyUtils.value(tree, name, ObjectExpression.class))
+      .map(objectExpression -> ObjectSymbol.fromPresent(ctx, objectExpression, name, this))
+      .orElse(ObjectSymbol.fromAbsent(ctx, name, this));
+  }
+}

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/symbols/ObjectSymbol.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/symbols/ObjectSymbol.java
@@ -17,12 +17,22 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonar.iac.arm.tree.api;
+package org.sonar.iac.arm.symbols;
 
-import org.sonar.iac.common.api.tree.PropertyTree;
+import javax.annotation.Nullable;
+import org.sonar.iac.arm.tree.api.ObjectExpression;
+import org.sonar.iac.common.api.checks.CheckContext;
 
-public interface Property extends PropertyTree, ArmTree {
-  Identifier key();
+public class ObjectSymbol extends MapSymbol<ObjectSymbol, ObjectExpression> {
+  protected ObjectSymbol(CheckContext ctx, @Nullable ObjectExpression tree, @Nullable String name, MapSymbol<?, ?> parent) {
+    super(ctx, tree, name, parent);
+  }
 
-  Expression value();
+  public static ObjectSymbol fromPresent(CheckContext ctx, ObjectExpression tree, @Nullable String name, MapSymbol<?, ?> parent) {
+    return new ObjectSymbol(ctx, tree, name, parent);
+  }
+
+  public static ObjectSymbol fromAbsent(CheckContext ctx, @Nullable String name, MapSymbol<?, ?> parent) {
+    return new ObjectSymbol(ctx, null, name, parent);
+  }
 }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/symbols/PropertySymbol.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/symbols/PropertySymbol.java
@@ -17,12 +17,25 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonar.iac.arm.tree.api;
+package org.sonar.iac.arm.symbols;
 
-import org.sonar.iac.common.api.tree.PropertyTree;
+import javax.annotation.Nullable;
+import org.sonar.iac.arm.tree.api.Expression;
+import org.sonar.iac.arm.tree.api.Property;
+import org.sonar.iac.common.api.checks.CheckContext;
+import org.sonar.iac.common.dsl.CommonPropertySymbol;
 
-public interface Property extends PropertyTree, ArmTree {
-  Identifier key();
+public class PropertySymbol extends CommonPropertySymbol<PropertySymbol, Property, Expression> {
 
-  Expression value();
+  public PropertySymbol(CheckContext ctx, @Nullable Property tree, String name, MapSymbol parent) {
+    super(ctx, tree, name, parent);
+  }
+
+  public static PropertySymbol fromPresent(CheckContext ctx, Property tree, MapSymbol parent) {
+    return new PropertySymbol(ctx, tree, tree.key().value(), parent);
+  }
+
+  public static PropertySymbol fromAbsent(CheckContext ctx, String name, MapSymbol parent) {
+    return new PropertySymbol(ctx, null, name, parent);
+  }
 }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/symbols/ResourceSymbol.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/symbols/ResourceSymbol.java
@@ -24,26 +24,25 @@ import org.sonar.iac.arm.tree.api.ResourceDeclaration;
 import org.sonar.iac.common.api.checks.CheckContext;
 import org.sonar.iac.common.api.checks.SecondaryLocation;
 import org.sonar.iac.common.api.tree.HasTextRange;
-import org.sonar.iac.common.dsl.MapSymbol;
 
-public class ResourceSymbol extends MapSymbol<ResourceSymbol, ResourceDeclaration> {
+public final class ResourceSymbol extends MapSymbol<ResourceSymbol, ResourceDeclaration> {
 
   public final String type;
   public final String version;
 
+  private ResourceSymbol(CheckContext ctx, ResourceDeclaration tree, String type) {
+    super(ctx, tree, tree.name().value(), null);
+    this.type = type;
+    this.version = tree.version().value();
+  }
+
   public static ResourceSymbol fromPresent(CheckContext ctx, ResourceDeclaration tree) {
-    return new ResourceSymbol(ctx, tree.type().value(), tree);
+    return new ResourceSymbol(ctx, tree, tree.type().value());
   }
 
   public static ResourceSymbol fromParent(ResourceSymbol parent, ResourceDeclaration child) {
     String type = parent.type + "/" + child.type().value();
-    return new ResourceSymbol(parent.ctx, type, child);
-  }
-
-  protected ResourceSymbol(CheckContext ctx, String type, ResourceDeclaration tree) {
-    super(ctx, tree, tree.name().value(), null);
-    this.type = type;
-    this.version = tree.version().value();
+    return new ResourceSymbol(parent.ctx, child, type);
   }
 
   @Override

--- a/iac-extensions/arm/src/test/java/org/sonar/iac/arm/ArmTestUtils.java
+++ b/iac-extensions/arm/src/test/java/org/sonar/iac/arm/ArmTestUtils.java
@@ -21,6 +21,8 @@ package org.sonar.iac.arm;
 
 import org.sonar.iac.arm.parser.ArmParser;
 import org.sonar.iac.arm.tree.api.File;
+import org.sonar.iac.arm.tree.api.ObjectExpression;
+import org.sonar.iac.arm.tree.api.Property;
 import org.sonar.iac.arm.tree.api.ResourceDeclaration;
 import org.sonar.iac.common.api.checks.CheckContext;
 
@@ -41,6 +43,32 @@ public class ArmTestUtils {
       "}");
     File file = (File) PARSER.parse(wrappedCode, null);
     return (ResourceDeclaration) file.statements().get(0);
+  }
+
+  public static Property parseProperty(String propertyCode) {
+    String wrappedPropertyCode = code("{",
+      "    \"name\": \"dummy resource\",",
+      "    \"type\": \"resource type\",",
+      "    \"apiVersion\": \"version\",",
+      "    \"properties\": {",
+      propertyCode,
+      "    }",
+      "}");
+    ResourceDeclaration resourceDeclaration = parseResource(wrappedPropertyCode);
+    return resourceDeclaration.properties().get(0);
+  }
+
+  public static ObjectExpression parseObject(String objectCode) {
+    String wrappedPropertyCode = code("{",
+      "    \"name\": \"dummy resource\",",
+      "    \"type\": \"resource type\",",
+      "    \"apiVersion\": \"version\",",
+      "    \"properties\": {",
+      "      \"object\": " + objectCode,
+      "    }",
+      "}");
+    ResourceDeclaration resourceDeclaration = parseResource(wrappedPropertyCode);
+    return (ObjectExpression) resourceDeclaration.properties().get(0).value();
   }
 
 }

--- a/iac-extensions/arm/src/test/java/org/sonar/iac/arm/symbols/MapSymbolTest.java
+++ b/iac-extensions/arm/src/test/java/org/sonar/iac/arm/symbols/MapSymbolTest.java
@@ -17,17 +17,15 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonar.iac.common.dsl;
+package org.sonar.iac.arm.symbols;
 
 import java.util.Collections;
 import java.util.List;
-import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.Test;
 import org.sonar.iac.common.api.checks.CheckContext;
 import org.sonar.iac.common.api.checks.SecondaryLocation;
 import org.sonar.iac.common.api.tree.HasProperties;
-import org.sonar.iac.common.api.tree.HasTextRange;
 import org.sonar.iac.common.api.tree.PropertyTree;
 import org.sonar.iac.common.api.tree.Tree;
 import org.sonar.iac.common.api.tree.impl.TextRange;
@@ -88,7 +86,7 @@ class MapSymbolTest {
     TestMapSymbol symbol = new TestMapSymbol(ctx, null, "testSymbol", parent);
     SecondaryLocation secondary = present.toSecondary("secondary");
     symbol.reportIfAbsent("message", secondary);
-    verify(ctx, times(1)).reportIssue(eq(tree), eq("message"), eq(List.of(secondary)));
+    verify(ctx, times(1)).reportIssue(tree, "message", List.of(secondary));
   }
 
   @Test
@@ -105,15 +103,8 @@ class MapSymbolTest {
   }
 
   static class TestMapSymbol extends MapSymbol<TestMapSymbol, TestTree> {
-
-    protected TestMapSymbol(CheckContext ctx, @Nullable TestTree tree, String name, @Nullable Symbol<? extends Tree> parent) {
+    protected TestMapSymbol(CheckContext ctx, @Nullable TestTree tree, @Nullable String name, @Nullable MapSymbol<?, ?> parent) {
       super(ctx, tree, name, parent);
-    }
-
-    @CheckForNull
-    @Override
-    protected HasTextRange toHighlight() {
-      return tree;
     }
   }
 

--- a/iac-extensions/arm/src/test/java/org/sonar/iac/arm/symbols/ObjectSymbolTest.java
+++ b/iac-extensions/arm/src/test/java/org/sonar/iac/arm/symbols/ObjectSymbolTest.java
@@ -1,0 +1,50 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.iac.arm.symbols;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.iac.arm.tree.api.ObjectExpression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.iac.arm.ArmTestUtils.CTX;
+import static org.sonar.iac.arm.ArmTestUtils.parseObject;
+
+class ObjectSymbolTest {
+
+  ObjectSymbol absent = ObjectSymbol.fromAbsent(CTX, "absentObject", null);
+  ObjectExpression objectWithProp = parseObject("{\"key1\": \"value\", \"key2\": {} }");
+  ObjectSymbol present = ObjectSymbol.fromPresent(CTX, objectWithProp, null, null);
+
+  @Test
+  void property() {
+    assertThat(present.property("key1").isPresent()).isTrue();
+    assertThat(present.property("key2").isPresent()).isTrue();
+    assertThat(present.property("unknown").isPresent()).isFalse();
+    assertThat(absent.property("key1").isPresent()).isFalse();
+  }
+
+  @Test
+  void object() {
+    assertThat(present.object("key1").isPresent()).isFalse();
+    assertThat(present.object("key2").isPresent()).isTrue();
+    assertThat(present.object("unknown").isPresent()).isFalse();
+    assertThat(absent.object("key1").isPresent()).isFalse();
+  }
+}

--- a/iac-extensions/arm/src/test/java/org/sonar/iac/arm/symbols/PropertySymbolTest.java
+++ b/iac-extensions/arm/src/test/java/org/sonar/iac/arm/symbols/PropertySymbolTest.java
@@ -1,0 +1,61 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.iac.arm.symbols;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.sonar.iac.arm.tree.api.Property;
+import org.sonar.iac.common.api.checks.SecondaryLocation;
+import org.sonar.iac.common.api.tree.HasTextRange;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.sonar.iac.arm.ArmTestUtils.CTX;
+import static org.sonar.iac.arm.ArmTestUtils.parseProperty;
+
+class PropertySymbolTest {
+
+  PropertySymbol absent = PropertySymbol.fromAbsent(CTX, "absentProperty", null);
+  Property property = parseProperty("\"key\": \"value\"");
+  PropertySymbol present = PropertySymbol.fromPresent(CTX, property, null);
+
+  @Test
+  void reportIfOnPresentProperty() {
+    present.reportIf(expression -> true, "message");
+    verify(CTX, times(1)).reportIssue(property, "message", Collections.emptyList());
+  }
+
+  @Test
+  void reportWithSecondaryLocation() {
+    SecondaryLocation secondary = present.toSecondary("secondary");
+    present.report("message", secondary);
+    verify(CTX, times(1)).reportIssue(property, "message", List.of(secondary));
+  }
+
+  @Test
+  void reportIfWhenPropertyIsAbsent() {
+    absent.reportIf(expression -> true, "message");
+    verify(CTX, never()).reportIssue(any(HasTextRange.class), anyString());
+  }
+}

--- a/iac-extensions/terraform/src/main/java/org/sonar/iac/terraform/symbols/AttributeSymbol.java
+++ b/iac-extensions/terraform/src/main/java/org/sonar/iac/terraform/symbols/AttributeSymbol.java
@@ -19,20 +19,12 @@
  */
 package org.sonar.iac.terraform.symbols;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Predicate;
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
 import org.sonar.iac.common.api.checks.CheckContext;
-import org.sonar.iac.common.api.checks.SecondaryLocation;
-import org.sonar.iac.common.api.tree.HasTextRange;
-import org.sonar.iac.common.checks.TextUtils;
-import org.sonar.iac.common.dsl.Symbol;
+import org.sonar.iac.common.dsl.CommonPropertySymbol;
 import org.sonar.iac.terraform.api.tree.AttributeTree;
 import org.sonar.iac.terraform.api.tree.ExpressionTree;
 
-public class AttributeSymbol extends Symbol<AttributeTree> {
+public class AttributeSymbol extends CommonPropertySymbol<AttributeSymbol, AttributeTree, ExpressionTree> {
 
   protected AttributeSymbol(CheckContext ctx, AttributeTree tree, String name, BlockSymbol parent) {
     super(ctx, tree, name, parent);
@@ -45,37 +37,4 @@ public class AttributeSymbol extends Symbol<AttributeTree> {
   public static AttributeSymbol fromAbsent(CheckContext ctx, String name, BlockSymbol parent) {
     return new AttributeSymbol(ctx, null, name, parent);
   }
-
-  public AttributeSymbol reportIf(Predicate<ExpressionTree> predicate, String message, SecondaryLocation... secondaries) {
-    if (tree != null && predicate.test(tree.value())) {
-      return (AttributeSymbol) report(message, List.of(secondaries));
-    }
-    return this;
-  }
-
-  public boolean is(Predicate<ExpressionTree> predicate) {
-    if (tree != null) {
-      return predicate.test(tree.value());
-    } else {
-      return predicate.test(null);
-    }
-  }
-
-  @Override
-  public AttributeSymbol reportIfAbsent(String message, SecondaryLocation... secondaries) {
-    super.reportIfAbsent(message, secondaries);
-    return this;
-  }
-
-  @CheckForNull
-  public String asString() {
-    return Optional.ofNullable(tree).flatMap(tree -> TextUtils.getValue(tree.value())).orElse(null);
-  }
-
-  @Nullable
-  @Override
-  protected HasTextRange toHighlight() {
-    return tree;
-  }
-
 }

--- a/iac-extensions/terraform/src/main/java/org/sonar/iac/terraform/symbols/BlockSymbol.java
+++ b/iac-extensions/terraform/src/main/java/org/sonar/iac/terraform/symbols/BlockSymbol.java
@@ -26,11 +26,11 @@ import javax.annotation.Nullable;
 import org.sonar.iac.common.api.checks.CheckContext;
 import org.sonar.iac.common.api.tree.HasTextRange;
 import org.sonar.iac.common.checks.PropertyUtils;
-import org.sonar.iac.common.dsl.MapSymbol;
+import org.sonar.iac.common.dsl.Symbol;
 import org.sonar.iac.terraform.api.tree.AttributeTree;
 import org.sonar.iac.terraform.api.tree.BlockTree;
 
-public class BlockSymbol extends MapSymbol<BlockSymbol, BlockTree> {
+public class BlockSymbol extends Symbol<BlockSymbol, BlockTree> {
 
   protected BlockSymbol(CheckContext ctx, BlockTree tree, String name, BlockSymbol parent) {
     super(ctx, tree, name, parent);

--- a/iac-extensions/terraform/src/main/java/org/sonar/iac/terraform/symbols/ListSymbol.java
+++ b/iac-extensions/terraform/src/main/java/org/sonar/iac/terraform/symbols/ListSymbol.java
@@ -33,7 +33,7 @@ import org.sonar.iac.terraform.api.tree.ExpressionTree;
 import org.sonar.iac.terraform.api.tree.TerraformTree;
 import org.sonar.iac.terraform.api.tree.TupleTree;
 
-public class ListSymbol extends Symbol<AttributeTree> {
+public class ListSymbol extends Symbol<ListSymbol, AttributeTree> {
 
   private final List<ExpressionTree> items;
 
@@ -83,11 +83,6 @@ public class ListSymbol extends Symbol<AttributeTree> {
 
   public boolean isByReference() {
     return tree != null && !tree.value().is(TerraformTree.Kind.TUPLE);
-  }
-
-  @Override
-  public ListSymbol reportIfAbsent(String message, SecondaryLocation... secondaries) {
-    return (ListSymbol) super.reportIfAbsent(message, secondaries);
   }
 
   @Nullable

--- a/iac-extensions/terraform/src/main/java/org/sonar/iac/terraform/symbols/ReferenceSymbol.java
+++ b/iac-extensions/terraform/src/main/java/org/sonar/iac/terraform/symbols/ReferenceSymbol.java
@@ -31,7 +31,7 @@ import org.sonar.iac.terraform.api.tree.TerraformTree;
 
 import static org.sonar.iac.terraform.checks.utils.TerraformUtils.attributeAccessToString;
 
-public class ReferenceSymbol extends Symbol<AttributeTree> {
+public class ReferenceSymbol extends Symbol<ReferenceSymbol, AttributeTree> {
 
   private AttributeAccessTree reference;
 


### PR DESCRIPTION
Removed the MapSymbol from the common package. It does not provide any value but only more complexity. Sorry for the number of files. However, it should not introduce more logic.