### PR TITLE
SONARIAC-813 Rule S6364: ARM Defining a short backup retention duration is security-sensitive (JSON) - Microsoft.RecoveryServices/vaults

### DIFF
--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/checks/ClearTextProtocolsCheck.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/checks/ClearTextProtocolsCheck.java
@@ -22,8 +22,8 @@ package org.sonar.iac.arm.checks;
 import org.sonar.check.Rule;
 import org.sonar.iac.arm.checkdsl.ContextualResource;
 
+import static org.sonar.iac.arm.checks.utils.CheckUtils.isEquals;
 import static org.sonar.iac.arm.checks.utils.CheckUtils.isFalse;
-import static org.sonar.iac.arm.checks.utils.CheckUtils.isValue;
 
 @Rule(key = "S5332")
 public class ClearTextProtocolsCheck extends AbstractArmResourceCheck {
@@ -45,6 +45,6 @@ public class ClearTextProtocolsCheck extends AbstractArmResourceCheck {
 
   private static void checkFtpsState(ContextualResource resource) {
     resource.property("ftpsState")
-      .reportIf(isValue("AllAllowed"), GENERAL_ISSUE_MESSAGE);
+      .reportIf(isEquals("AllAllowed"), GENERAL_ISSUE_MESSAGE);
   }
 }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/checks/ClearTextProtocolsCheck.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/checks/ClearTextProtocolsCheck.java
@@ -22,7 +22,7 @@ package org.sonar.iac.arm.checks;
 import org.sonar.check.Rule;
 import org.sonar.iac.arm.checkdsl.ContextualResource;
 
-import static org.sonar.iac.arm.checks.utils.CheckUtils.isEquals;
+import static org.sonar.iac.arm.checks.utils.CheckUtils.isEqual;
 import static org.sonar.iac.arm.checks.utils.CheckUtils.isFalse;
 
 @Rule(key = "S5332")
@@ -45,6 +45,6 @@ public class ClearTextProtocolsCheck extends AbstractArmResourceCheck {
 
   private static void checkFtpsState(ContextualResource resource) {
     resource.property("ftpsState")
-      .reportIf(isEquals("AllAllowed"), GENERAL_ISSUE_MESSAGE);
+      .reportIf(isEqual("AllAllowed"), GENERAL_ISSUE_MESSAGE);
   }
 }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/checks/LogRetentionCheck.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/checks/LogRetentionCheck.java
@@ -91,7 +91,7 @@ public class LogRetentionCheck extends AbstractArmResourceCheck {
       if (!expr.is(ArmTree.Kind.NUMERIC_LITERAL)) {
         return false;
       }
-      float retentionDays = ((NumericLiteral) expr).value();
+      double retentionDays = ((NumericLiteral) expr).value();
       return retentionDays < retentionPeriodInDays && retentionDays != 0;
     };
   }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/checks/ShortBackupRetentionCheck.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/checks/ShortBackupRetentionCheck.java
@@ -19,14 +19,26 @@
  */
 package org.sonar.iac.arm.checks;
 
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.DoublePredicate;
+import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
 import org.sonar.iac.arm.checkdsl.ContextualObject;
+import org.sonar.iac.arm.checkdsl.ContextualProperty;
 import org.sonar.iac.arm.checkdsl.ContextualResource;
 import org.sonar.iac.arm.tree.api.ArmTree;
 import org.sonar.iac.arm.tree.api.Expression;
 import org.sonar.iac.arm.tree.api.NumericLiteral;
+import org.sonar.iac.arm.tree.api.Property;
+import org.sonar.iac.arm.tree.api.StringLiteral;
+import org.sonar.iac.common.api.tree.Tree;
 
 import static org.sonar.iac.arm.checks.utils.CheckUtils.isValue;
 
@@ -35,6 +47,14 @@ public class ShortBackupRetentionCheck extends AbstractArmResourceCheck {
 
   private static final String RETENTION_PERIOD_TOO_SHORT_MESSAGE = "Make sure that defining a short backup retention duration is safe here.";
   private static final String NO_RETENTION_PERIOD_PROPERTY_MESSAGE = "Omitting \"%s\" causes a short backup retention period to be set. " + RETENTION_PERIOD_TOO_SHORT_MESSAGE;
+
+  private static final Set<String> TYPES_BASIC_RETENTION = Set.of("AzureIaasVM", "AzureSql", "AzureStorage", "MAB");
+  private static final Set<String> TYPES_SUBPROTECTION_RETENTION = Set.of("GenericProtectionPolicy", "AzureWorkload");
+  private static final Map<String, Function<Double, Double>> POLICY_TO_DAYS = Map.of(
+    "Days", days -> days,
+    "Weeks", days -> days * 7.0,
+    "Months", days -> days * 30.0,
+    "Years", days -> days * 365.0);
 
   private static final int DEFAULT_RETENTION_PERIOD = 30;
 
@@ -48,6 +68,7 @@ public class ShortBackupRetentionCheck extends AbstractArmResourceCheck {
   protected void registerResourceConsumer() {
     register("Microsoft.Web/sites/config", this::checkBackupRetentionWebSitesConfig);
     register("Microsoft.DocumentDB/databaseAccounts", this::checkBackupRetentionDatabaseAccounts);
+    register("Microsoft.RecoveryServices/vaults/backupPolicies", this::checkBackupRetentionRecoveryServicesVaults);
   }
 
   private void checkBackupRetentionWebSitesConfig(ContextualResource resource) {
@@ -69,7 +90,75 @@ public class ShortBackupRetentionCheck extends AbstractArmResourceCheck {
     }
   }
 
-  private static Predicate<Expression> isNumericValue(Predicate<Float> predicate) {
+  private void checkBackupRetentionRecoveryServicesVaults(ContextualResource resource) {
+    retrieveRetentionPolicyObjects(resource).forEach(retentionPolicyObject -> {
+      ContextualObject retentionDurationObject = retrieveRetentionDurationObject(retentionPolicyObject);
+      Double durationInDays = computeRetentionInDays(retentionDurationObject);
+      if (durationInDays != null && durationInDays < retentionPeriodInDays) {
+        retentionDurationObject.property("count").report(RETENTION_PERIOD_TOO_SHORT_MESSAGE, retentionDurationObject.property("durationType").toSecondary("Duration type"));
+      }
+    });
+  }
+
+  private static Stream<ContextualObject> retrieveRetentionPolicyObjects(ContextualResource resource) {
+    ContextualProperty backupManagementType = resource.property("backupManagementType");
+
+    if (backupManagementType.is(isValue(TYPES_BASIC_RETENTION::contains))) {
+      return Stream.of(resource.object("retentionPolicy"));
+    } else if (backupManagementType.is(isValue(TYPES_SUBPROTECTION_RETENTION::contains))) {
+      return resource.list("subProtectionPolicy")
+        .objects()
+        .map(contextualObject -> contextualObject.object("retentionPolicy"));
+    } else {
+      return Stream.empty();
+    }
+  }
+
+  private static ContextualObject retrieveRetentionDurationObject(ContextualObject retentionPolicyObject) {
+    ContextualProperty retentionPolicyType = retentionPolicyObject.property("retentionPolicyType");
+
+    if (retentionPolicyType.is(isValue("SimpleRetentionPolicy"::equals))) {
+      return retentionPolicyObject.object("retentionDuration");
+    } else if (retentionPolicyType.is(isValue("LongTermRetentionPolicy"::equals))) {
+      return retentionPolicyObject.object("dailySchedule").object("retentionDuration");
+    } else {
+      return ContextualObject.fromAbsent(retentionPolicyObject.ctx, null, retentionPolicyObject);
+    }
+  }
+
+  @CheckForNull
+  private static Double computeRetentionInDays(ContextualObject retentionPolicyObject) {
+    Double count = toDouble(retentionPolicyObject.property("count").tree);
+    String durationType = toString(retentionPolicyObject.property("durationType").tree);
+
+    if (count != null && durationType != null) {
+      return POLICY_TO_DAYS.getOrDefault(durationType, val -> null).apply(count);
+    } else {
+      return null;
+    }
+  }
+
+  private static Predicate<Expression> isNumericValue(DoublePredicate predicate) {
     return expr -> expr.is(ArmTree.Kind.NUMERIC_LITERAL) && predicate.test(((NumericLiteral) expr).value());
+  }
+
+  @CheckForNull
+  private static Double toDouble(@Nullable Tree tree) {
+    return Optional.ofNullable(tree)
+      .map(Property.class::cast)
+      .map(Property::value)
+      .filter(expr -> expr.is(ArmTree.Kind.NUMERIC_LITERAL))
+      .map(expr -> ((NumericLiteral) expr).value())
+      .orElse(null);
+  }
+
+  @CheckForNull
+  private static String toString(@Nullable Tree tree) {
+    return Optional.ofNullable(tree)
+      .map(Property.class::cast)
+      .map(Property::value)
+      .filter(expr -> expr.is(ArmTree.Kind.STRING_LITERAL))
+      .map(expr -> ((StringLiteral) expr).value())
+      .orElse(null);
   }
 }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/checks/ShortBackupRetentionCheck.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/checks/ShortBackupRetentionCheck.java
@@ -40,7 +40,7 @@ import org.sonar.iac.arm.tree.api.Property;
 import org.sonar.iac.arm.tree.api.StringLiteral;
 import org.sonar.iac.common.api.tree.Tree;
 
-import static org.sonar.iac.arm.checks.utils.CheckUtils.isEquals;
+import static org.sonar.iac.arm.checks.utils.CheckUtils.isEqual;
 import static org.sonar.iac.arm.checks.utils.CheckUtils.isValue;
 
 @Rule(key = "S6364")
@@ -82,7 +82,7 @@ public class ShortBackupRetentionCheck extends AbstractArmResourceCheck {
 
   private void checkBackupRetentionDatabaseAccounts(ContextualResource resource) {
     ContextualObject backupPolicy = resource.object("backupPolicy");
-    if (backupPolicy.property("type").is(isEquals("Periodic"))) {
+    if (backupPolicy.property("type").is(isEqual("Periodic"))) {
       backupPolicy.object("periodicModeProperties")
         .reportIfAbsent(String.format(NO_RETENTION_PERIOD_PROPERTY_MESSAGE, "periodicModeProperties.backupRetentionIntervalInHours"))
         .property("backupRetentionIntervalInHours")
@@ -118,9 +118,9 @@ public class ShortBackupRetentionCheck extends AbstractArmResourceCheck {
   private static ContextualObject retrieveRetentionDuration(ContextualObject retentionPolicyObject) {
     ContextualProperty retentionPolicyType = retentionPolicyObject.property("retentionPolicyType");
 
-    if (retentionPolicyType.is(isEquals("SimpleRetentionPolicy"))) {
+    if (retentionPolicyType.is(isEqual("SimpleRetentionPolicy"))) {
       return retentionPolicyObject.object("retentionDuration");
-    } else if (retentionPolicyType.is(isEquals("LongTermRetentionPolicy"))) {
+    } else if (retentionPolicyType.is(isEqual("LongTermRetentionPolicy"))) {
       return retentionPolicyObject.object("dailySchedule").object("retentionDuration");
     } else {
       return ContextualObject.fromAbsent(retentionPolicyObject.ctx, null, retentionPolicyObject);

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/checks/utils/CheckUtils.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/checks/utils/CheckUtils.java
@@ -83,8 +83,8 @@ public class CheckUtils {
     return expr -> TextUtils.matchesValue(expr, predicate).isTrue();
   }
 
-  public static Predicate<Expression> isValue(String stringToMatch) {
-    return expr -> TextUtils.isValue(expr, stringToMatch).isTrue();
+  public static Predicate<Expression> isEquals(String targetString) {
+    return expr -> TextUtils.matchesValue(expr, targetString::equals).isTrue();
   }
 
   public static Predicate<Expression> isFalse() {

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/checks/utils/CheckUtils.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/checks/utils/CheckUtils.java
@@ -83,7 +83,7 @@ public class CheckUtils {
     return expr -> TextUtils.matchesValue(expr, predicate).isTrue();
   }
 
-  public static Predicate<Expression> isEquals(String targetString) {
+  public static Predicate<Expression> isEqual(String targetString) {
     return expr -> TextUtils.matchesValue(expr, targetString::equals).isTrue();
   }
 

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/NumericLiteral.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/api/NumericLiteral.java
@@ -20,5 +20,5 @@
 package org.sonar.iac.arm.tree.api;
 
 public interface NumericLiteral extends Expression {
-  float value();
+  double value();
 }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/NumericLiteralImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/json/NumericLiteralImpl.java
@@ -24,7 +24,7 @@ import org.sonar.iac.common.yaml.tree.YamlTreeMetadata;
 
 public class NumericLiteralImpl extends ExpressionImpl implements NumericLiteral {
 
-  private final float value;
+  private final double value;
 
   public NumericLiteralImpl(float value, YamlTreeMetadata metadata) {
     super(metadata);
@@ -37,7 +37,7 @@ public class NumericLiteralImpl extends ExpressionImpl implements NumericLiteral
   }
 
   @Override
-  public float value() {
+  public double value() {
     return value;
   }
 }

--- a/iac-extensions/arm/src/test/java/org/sonar/iac/arm/checks/ShortBackupRetentionCheckTest.java
+++ b/iac-extensions/arm/src/test/java/org/sonar/iac/arm/checks/ShortBackupRetentionCheckTest.java
@@ -20,6 +20,7 @@
 package org.sonar.iac.arm.checks;
 
 import org.junit.jupiter.api.Test;
+import org.sonar.iac.common.api.checks.SecondaryLocation;
 
 import static org.sonar.iac.common.testing.Verifier.issue;
 
@@ -64,5 +65,34 @@ class ShortBackupRetentionCheckTest {
     ArmVerifier.verify("ShortBackupRetentionCheck/Microsoft.DocumentDB_databaseAccounts_custom.json",
       check,
       issue(13, 12, 13, 48, "Make sure that defining a short backup retention duration is safe here."));
+  }
+
+  @Test
+  void testRecoveryServicesVaultsBackupPolicies() {
+    ArmVerifier.verify("ShortBackupRetentionCheck/Microsoft.RecoveryServices_vaults.json",
+      check,
+      issue(14, 12, 14, 22, "Make sure that defining a short backup retention duration is safe here.",
+        SecondaryLocation.secondary(15, 12, 15, 34, "Duration type")),
+      issue(29, 12, 29, 22),
+      issue(44, 12, 44, 22),
+      issue(59, 12, 59, 22),
+      issue(76, 16, 76, 26),
+      issue(95, 16, 95, 26),
+      issue(113, 14, 113, 24),
+      issue(130, 14, 130, 25),
+      issue(147, 14, 147, 24),
+      issue(171, 22, 171, 32));
+  }
+
+  @Test
+  void testRecoveryServicesVaultsBackupPoliciesCustomRetentionPeriod() {
+    check.retentionPeriodInDays = 400;
+    ArmVerifier.verify("ShortBackupRetentionCheck/Microsoft.RecoveryServices_vaults_custom_400.json",
+      check,
+      issue(15, 14, 15, 25, "Make sure that defining a short backup retention duration is safe here.",
+        SecondaryLocation.secondary(16, 14, 16, 36, "Duration type")),
+      issue(32, 14, 32, 25),
+      issue(49, 14, 49, 24),
+      issue(66, 14, 66, 24));
   }
 }

--- a/iac-extensions/arm/src/test/resources/checks/ShortBackupRetentionCheck/Microsoft.RecoveryServices_vaults.json
+++ b/iac-extensions/arm/src/test/resources/checks/ShortBackupRetentionCheck/Microsoft.RecoveryServices_vaults.json
@@ -1,0 +1,399 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "name": "Sensitive: test case sensitive backupManagementType 'AzureIaasVM'",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "SimpleRetentionPolicy",
+          "retentionDuration": {
+            "count": 7,
+            "durationType": "Days"
+          }
+        }
+      }
+    },
+    {
+      "name": "Sensitive: test case sensitive backupManagementType 'AzureSql'",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureSql",
+        "retentionPolicy": {
+          "retentionPolicyType": "SimpleRetentionPolicy",
+          "retentionDuration": {
+            "count": 7,
+            "durationType": "Days"
+          }
+        }
+      }
+    },
+    {
+      "name": "Sensitive: test case sensitive backupManagementType 'AzureStorage'",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureStorage",
+        "retentionPolicy": {
+          "retentionPolicyType": "SimpleRetentionPolicy",
+          "retentionDuration": {
+            "count": 7,
+            "durationType": "Days"
+          }
+        }
+      }
+    },
+    {
+      "name": "Sensitive: test case sensitive backupManagementType 'MAB'",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "MAB",
+        "retentionPolicy": {
+          "retentionPolicyType": "SimpleRetentionPolicy",
+          "retentionDuration": {
+            "count": 7,
+            "durationType": "Days"
+          }
+        }
+      }
+    },
+    {
+      "name": "Sensitive: test case sensitive subProtectionPolicy 'GenericProtectionPolicy'",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "GenericProtectionPolicy",
+        "subProtectionPolicy": [
+          {
+            "retentionPolicy": {
+              "retentionPolicyType": "SimpleRetentionPolicy",
+              "retentionDuration": {
+                "count": 7,
+                "durationType": "Days"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Sensitive: test case sensitive subProtectionPolicy 'AzureWorkload'",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureWorkload",
+        "subProtectionPolicy": [
+          {
+            "retentionPolicy": {
+              "retentionPolicyType": "SimpleRetentionPolicy",
+              "retentionDuration": {
+                "count": 7,
+                "durationType": "Days"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Sensitive: test case with retentionPolicyType=LongTermRetentionPolicy",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 7,
+              "durationType": "Days"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Sensitive: durationType in days with less than 30 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 15,
+              "durationType": "Days"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Sensitive: durationType in weeks with less than 30 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 4,
+              "durationType": "Weeks"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Sensitive inner child case",
+      "type": "Microsoft.RecoveryServices/vaults",
+      "apiVersion": "2023-01-01",
+      "resources": [
+        {
+          "name": "Inner child",
+          "type": "backupPolicies",
+          "apiVersion": "2023-01-01",
+          "properties": {
+            "backupManagementType": "GenericProtectionPolicy",
+            "subProtectionPolicy": [
+              {
+                "retentionPolicy": {
+                  "retentionPolicyType": "LongTermRetentionPolicy",
+                  "dailySchedule": {
+                    "retentionDuration": {
+                      "count": 1,
+                      "durationType": "Days"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    },
+    
+    {
+      "name": "Compliant: durationType in days with more than 30 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 50,
+              "durationType": "Days"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Compliant: durationType in days with exactly 30 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 30,
+              "durationType": "Days"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Compliant: durationType in weeks with more than 30 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 5,
+              "durationType": "Weeks"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Compliant: durationType in months with more than 30 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 1,
+              "durationType": "Months"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Compliant: durationType in years with more than 30 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 1,
+              "durationType": "Years"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Compliant: test case backupManagementType with value 'unknown'",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "unknown",
+        "retentionPolicy": {
+          "retentionPolicyType": "SimpleRetentionPolicy",
+          "retentionDuration": {
+            "count": 7,
+            "durationType": "Days"
+          }
+        }
+      }
+    },
+    {
+      "name": "Compliant: test case retentionPolicyType with value 'unknown'",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "unknown",
+          "retentionDuration": {
+            "count": 7,
+            "durationType": "Days"
+          },
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 7,
+              "durationType": "Days"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Compliant: durationType is unknown",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 0,
+              "durationType": "unknown"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Compliant: test case subProtectionPolicy 'unknown'",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "unknown",
+        "subProtectionPolicy": [
+          {
+            "retentionPolicy": {
+              "retentionPolicyType": "LongTermRetentionPolicy",
+              "dailySchedule": {
+                "retentionDuration": {
+                  "count": 7,
+                  "durationType": "Days"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Compliant: durationType property is missing",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "SimpleRetentionPolicy",
+          "retentionDuration": {
+            "count": 7
+          }
+        }
+      }
+    },
+    {
+      "name": "Compliant: count property is missing",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "SimpleRetentionPolicy",
+          "retentionDuration": {
+            "durationType": "Days"
+          }
+        }
+      }
+    },
+    {
+      "name": "Sensitive inner child case",
+      "type": "Microsoft.RecoveryServices/vaults",
+      "apiVersion": "2023-01-01",
+      "resources": [
+        {
+          "name": "Inner child",
+          "type": "backupPolicies",
+          "apiVersion": "2023-01-01",
+          "properties": {
+            "backupManagementType": "GenericProtectionPolicy",
+            "subProtectionPolicy": [
+              {
+                "retentionPolicy": {
+                  "retentionPolicyType": "LongTermRetentionPolicy",
+                  "dailySchedule": {
+                    "retentionDuration": {
+                      "count": 50,
+                      "durationType": "Days"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/iac-extensions/arm/src/test/resources/checks/ShortBackupRetentionCheck/Microsoft.RecoveryServices_vaults_custom_400.json
+++ b/iac-extensions/arm/src/test/resources/checks/ShortBackupRetentionCheck/Microsoft.RecoveryServices_vaults_custom_400.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "name": "Sensitive: durationType in days with less than 400 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 10,
+              "durationType": "Days"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Sensitive: durationType in weeks with less than 400 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 10,
+              "durationType": "Weeks"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Sensitive: durationType in months with less than 400 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 5,
+              "durationType": "Months"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Sensitive: durationType in years with less than 400 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 1,
+              "durationType": "Years"
+            }
+          }
+        }
+      }
+    },
+    
+    {
+      "name": "Compliant: durationType in days with more than 400 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 500,
+              "durationType": "Days"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Compliant: durationType in days with exactly 400 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 400,
+              "durationType": "Days"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Compliant: durationType in weeks with more than 400 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 70,
+              "durationType": "Weeks"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Compliant: durationType in months with more than 400 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 24,
+              "durationType": "Months"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "Compliant: durationType in years with more than 400 days",
+      "type": "Microsoft.RecoveryServices/vaults/backupPolicies",
+      "apiVersion": "2023-01-01",
+      "properties": {
+        "backupManagementType": "AzureIaasVM",
+        "retentionPolicy": {
+          "retentionPolicyType": "LongTermRetentionPolicy",
+          "dailySchedule": {
+            "retentionDuration": {
+              "count": 2,
+              "durationType": "Years"
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR also update our model to use a double instead of a float to handle NumericLiteral.
I did it this way because otherwise, it raises a Bug in Sonar when I perform multiply on those numbers.