### PR TITLE
SONARIAC-986 Bicep Arrays: support comma-separated arrays

### DIFF
--- a/iac-common/src/main/java/org/sonar/iac/common/api/tree/impl/SeparatedListImpl.java
+++ b/iac-common/src/main/java/org/sonar/iac/common/api/tree/impl/SeparatedListImpl.java
@@ -71,17 +71,6 @@ public class SeparatedListImpl<T extends Tree, U extends IacToken> implements Se
     return result;
   }
 
-  public static <R extends Tree, S extends IacToken> SeparatedListImpl<R, S> separatedListOptionalSeparator(List<Tuple<Optional<S>, R>> elementsWithOptionalsSeparators) {
-    if (elementsWithOptionalsSeparators.isEmpty()) {
-      return emptySeparatedList();
-    } else {
-      List<Tuple<S, R>> elementsWithNullSeparators = elementsWithOptionalsSeparators.stream()
-        .map(tuple -> new Tuple<>(tuple.first().orNull(), tuple.second()))
-        .collect(Collectors.toList());
-      return separatedList(elementsWithNullSeparators.remove(0).second(), elementsWithNullSeparators);
-    }
-  }
-
   public static <R extends Tree, S extends IacToken> SeparatedListImpl<R, S> separatedList(R firstElement, Optional<List<Tuple<S, R>>> additionalElements) {
     return separatedList(firstElement, additionalElements.or(Collections.emptyList()));
   }

--- a/iac-common/src/test/java/org/sonar/iac/common/api/tree/impl/SeparatedListImplTest.java
+++ b/iac-common/src/test/java/org/sonar/iac/common/api/tree/impl/SeparatedListImplTest.java
@@ -20,7 +20,6 @@
 package org.sonar.iac.common.api.tree.impl;
 
 import com.sonar.sslr.api.typed.Optional;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.sonar.iac.common.api.tree.IacToken;
@@ -29,7 +28,6 @@ import org.sonar.iac.common.api.tree.Tree;
 import org.sonar.iac.common.checks.CommonTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.sonar.iac.common.api.tree.impl.SeparatedListImpl.separatedListOptionalSeparator;
 
 class SeparatedListImplTest {
 
@@ -56,6 +54,18 @@ class SeparatedListImplTest {
   }
 
   @Test
+  void separatedListWithNullSeparator() {
+    Tree firstElement = CommonTestUtils.TestTree.tree();
+    Tree tupleElement = CommonTestUtils.TestTree.tree();
+
+    SeparatedList<Tree, IacToken> resultingSeparatedList = SeparatedListImpl.separatedList(firstElement, Optional.of(List.of(new Tuple<>(null, tupleElement))));
+
+    assertThat(resultingSeparatedList.elements()).containsExactly(firstElement, tupleElement);
+    assertThat(resultingSeparatedList.separators()).isEmpty();
+    assertThat(resultingSeparatedList.elementsAndSeparators()).containsExactly(firstElement, tupleElement);
+  }
+
+  @Test
   void absentOptionalShouldRetrieveSeparatedListWithOnlyOneElement() {
     Tree firstElement = CommonTestUtils.TestTree.tree();
 
@@ -63,32 +73,5 @@ class SeparatedListImplTest {
 
     assertThat(resultingSeparatedList.elements()).containsExactly(firstElement);
     assertThat(resultingSeparatedList.separators()).isEmpty();
-  }
-
-  @Test
-  void separatedListWithOptionalSeparators() {
-    // Three elements list with only first separator: tree1, tree2, separator1, tree3
-    Tree tree1 = CommonTestUtils.TestTree.tree();
-    Tree tree2 = CommonTestUtils.TestTree.tree();
-    Tree tree3 = CommonTestUtils.TestTree.tree();
-    IacToken separator1 = CommonTestUtils.TestIacToken.token();
-
-    List<Tuple<Optional<IacToken>, Tree>> elementsWithOptionalSeparators = List.of(
-      new Tuple<>(Optional.absent(), tree1),
-      new Tuple<>(Optional.absent(), tree2),
-      new Tuple<>(Optional.of(separator1), tree3));
-    SeparatedList<Tree, IacToken> separatedList = separatedListOptionalSeparator(elementsWithOptionalSeparators);
-
-    assertThat(separatedList.elements()).containsExactly(tree1, tree2, tree3);
-    assertThat(separatedList.separators()).containsExactly(separator1);
-    assertThat(separatedList.elementsAndSeparators()).containsExactly(tree1, tree2, separator1, tree3);
-  }
-
-  @Test
-  void separatedListWithOptionalSeparatorsEmpty() {
-    SeparatedList<Tree, IacToken> separatedList = separatedListOptionalSeparator(Collections.emptyList());
-    assertThat(separatedList.elements()).isEmpty();
-    assertThat(separatedList.separators()).isEmpty();
-    assertThat(separatedList.elementsAndSeparators()).isEmpty();
   }
 }

--- a/iac-common/src/test/java/org/sonar/iac/common/api/tree/impl/SeparatedListImplTest.java
+++ b/iac-common/src/test/java/org/sonar/iac/common/api/tree/impl/SeparatedListImplTest.java
@@ -20,6 +20,7 @@
 package org.sonar.iac.common.api.tree.impl;
 
 import com.sonar.sslr.api.typed.Optional;
+import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.sonar.iac.common.api.tree.IacToken;
@@ -28,6 +29,7 @@ import org.sonar.iac.common.api.tree.Tree;
 import org.sonar.iac.common.checks.CommonTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.iac.common.api.tree.impl.SeparatedListImpl.separatedListOptionalSeparator;
 
 class SeparatedListImplTest {
 
@@ -61,5 +63,32 @@ class SeparatedListImplTest {
 
     assertThat(resultingSeparatedList.elements()).containsExactly(firstElement);
     assertThat(resultingSeparatedList.separators()).isEmpty();
+  }
+
+  @Test
+  void separatedListWithOptionalSeparators() {
+    // Three elements list with only first separator: tree1, tree2, separator1, tree3
+    Tree tree1 = CommonTestUtils.TestTree.tree();
+    Tree tree2 = CommonTestUtils.TestTree.tree();
+    Tree tree3 = CommonTestUtils.TestTree.tree();
+    IacToken separator1 = CommonTestUtils.TestIacToken.token();
+
+    List<Tuple<Optional<IacToken>, Tree>> elementsWithOptionalSeparators = List.of(
+      new Tuple<>(Optional.absent(), tree1),
+      new Tuple<>(Optional.absent(), tree2),
+      new Tuple<>(Optional.of(separator1), tree3));
+    SeparatedList<Tree, IacToken> separatedList = separatedListOptionalSeparator(elementsWithOptionalSeparators);
+
+    assertThat(separatedList.elements()).containsExactly(tree1, tree2, tree3);
+    assertThat(separatedList.separators()).containsExactly(separator1);
+    assertThat(separatedList.elementsAndSeparators()).containsExactly(tree1, tree2, separator1, tree3);
+  }
+
+  @Test
+  void separatedListWithOptionalSeparatorsEmpty() {
+    SeparatedList<Tree, IacToken> separatedList = separatedListOptionalSeparator(Collections.emptyList());
+    assertThat(separatedList.elements()).isEmpty();
+    assertThat(separatedList.separators()).isEmpty();
+    assertThat(separatedList.elementsAndSeparators()).isEmpty();
   }
 }

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/parser/bicep/BicepGrammar.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/parser/bicep/BicepGrammar.java
@@ -422,7 +422,10 @@ public class BicepGrammar {
     return b.<ArrayExpression>nonterminal(BicepLexicalGrammar.ARRAY_EXPRESSION).is(
       f.arrayExpression(
         b.token(Punctuator.LBRACKET),
-        b.zeroOrMore(EXPRESSION()),
+        b.zeroOrMore(
+          f.tuple(
+            b.optional(b.token(Punctuator.COMMA)),
+            EXPRESSION())),
         b.token(Punctuator.RBRACKET)));
   }
 

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/parser/bicep/TreeFactory.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/parser/bicep/TreeFactory.java
@@ -20,8 +20,8 @@
 package org.sonar.iac.arm.parser.bicep;
 
 import com.sonar.sslr.api.typed.Optional;
-import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.sonar.iac.arm.tree.api.ArmTree;
 import org.sonar.iac.arm.tree.api.ArrayExpression;
 import org.sonar.iac.arm.tree.api.BooleanLiteral;
@@ -142,7 +142,6 @@ import org.sonar.iac.common.api.tree.impl.Tuple;
 import static java.util.Collections.emptyList;
 import static org.sonar.iac.common.api.tree.impl.SeparatedListImpl.emptySeparatedList;
 import static org.sonar.iac.common.api.tree.impl.SeparatedListImpl.separatedList;
-import static org.sonar.iac.common.api.tree.impl.SeparatedListImpl.separatedListOptionalSeparator;
 
 public class TreeFactory {
 
@@ -329,7 +328,16 @@ public class TreeFactory {
   }
 
   public ArrayExpression arrayExpression(SyntaxToken lBracket, Optional<List<Tuple<Optional<SyntaxToken>, Expression>>> elements, SyntaxToken rBracket) {
-    return new ArrayExpressionImpl(lBracket, separatedListOptionalSeparator(elements.or(Collections.emptyList())), rBracket);
+    SeparatedList<Expression, SyntaxToken> arrayContent = emptySeparatedList();
+    if (elements.isPresent()) {
+      // replace Optional<SyntaxToken> by SyntaxToken or null
+      List<Tuple<SyntaxToken, Expression>> elementsWithNullSeparators = elements.get().stream()
+        .map(tuple -> new Tuple<>(tuple.first().orNull(), tuple.second()))
+        .collect(Collectors.toList());
+      Expression firstElement = elementsWithNullSeparators.remove(0).second();
+      arrayContent = separatedList(firstElement, elementsWithNullSeparators);
+    }
+    return new ArrayExpressionImpl(lBracket, arrayContent, rBracket);
   }
 
   public NumericLiteral numericLiteral(SyntaxToken token) {

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/parser/bicep/TreeFactory.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/parser/bicep/TreeFactory.java
@@ -20,6 +20,7 @@
 package org.sonar.iac.arm.parser.bicep;
 
 import com.sonar.sslr.api.typed.Optional;
+import java.util.Collections;
 import java.util.List;
 import org.sonar.iac.arm.tree.api.ArmTree;
 import org.sonar.iac.arm.tree.api.ArrayExpression;
@@ -141,6 +142,7 @@ import org.sonar.iac.common.api.tree.impl.Tuple;
 import static java.util.Collections.emptyList;
 import static org.sonar.iac.common.api.tree.impl.SeparatedListImpl.emptySeparatedList;
 import static org.sonar.iac.common.api.tree.impl.SeparatedListImpl.separatedList;
+import static org.sonar.iac.common.api.tree.impl.SeparatedListImpl.separatedListOptionalSeparator;
 
 public class TreeFactory {
 
@@ -326,11 +328,8 @@ public class TreeFactory {
     return new ObjectExpressionImpl(leftCurlyBrace, properties.or(emptyList()), rightCurlyBrace);
   }
 
-  public ArrayExpression arrayExpression(
-    SyntaxToken lBracket,
-    Optional<List<Expression>> elements,
-    SyntaxToken rBracket) {
-    return new ArrayExpressionImpl(lBracket, elements.or(emptyList()), rBracket);
+  public ArrayExpression arrayExpression(SyntaxToken lBracket, Optional<List<Tuple<Optional<SyntaxToken>, Expression>>> elements, SyntaxToken rBracket) {
+    return new ArrayExpressionImpl(lBracket, separatedListOptionalSeparator(elements.or(Collections.emptyList())), rBracket);
   }
 
   public NumericLiteral numericLiteral(SyntaxToken token) {

--- a/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/bicep/ArrayExpressionImpl.java
+++ b/iac-extensions/arm/src/main/java/org/sonar/iac/arm/tree/impl/bicep/ArrayExpressionImpl.java
@@ -25,14 +25,15 @@ import org.sonar.iac.arm.tree.api.ArrayExpression;
 import org.sonar.iac.arm.tree.api.Expression;
 import org.sonar.iac.arm.tree.api.bicep.SyntaxToken;
 import org.sonar.iac.arm.tree.impl.AbstractArmTreeImpl;
+import org.sonar.iac.common.api.tree.SeparatedList;
 import org.sonar.iac.common.api.tree.Tree;
 
 public class ArrayExpressionImpl extends AbstractArmTreeImpl implements ArrayExpression {
   private final SyntaxToken lBracket;
-  private final List<Expression> elements;
+  private final SeparatedList<Expression, SyntaxToken> elements;
   private final SyntaxToken rBracket;
 
-  public ArrayExpressionImpl(SyntaxToken lBracket, List<Expression> elements, SyntaxToken rBracket) {
+  public ArrayExpressionImpl(SyntaxToken lBracket, SeparatedList<Expression, SyntaxToken> elements, SyntaxToken rBracket) {
     this.lBracket = lBracket;
     this.elements = elements;
     this.rBracket = rBracket;
@@ -42,13 +43,13 @@ public class ArrayExpressionImpl extends AbstractArmTreeImpl implements ArrayExp
   public List<Tree> children() {
     List<Tree> children = new ArrayList<>();
     children.add(lBracket);
-    children.addAll(elements);
+    children.addAll(elements.elementsAndSeparators());
     children.add(rBracket);
     return children;
   }
 
   @Override
   public List<Expression> elements() {
-    return elements;
+    return elements.elements();
   }
 }

--- a/iac-extensions/arm/src/test/java/org/sonar/iac/arm/tree/impl/bicep/ArrayExpressionImplTest.java
+++ b/iac-extensions/arm/src/test/java/org/sonar/iac/arm/tree/impl/bicep/ArrayExpressionImplTest.java
@@ -25,7 +25,10 @@ import org.sonar.iac.arm.ArmAssertions;
 import org.sonar.iac.arm.parser.bicep.BicepLexicalGrammar;
 import org.sonar.iac.arm.tree.api.ArmTree;
 import org.sonar.iac.arm.tree.api.ArrayExpression;
+import org.sonar.iac.arm.tree.api.bicep.StringComplete;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.sonar.iac.arm.ArmTestUtils.recursiveTransformationOfTreeChildrenToStrings;
 import static org.sonar.iac.common.testing.IacTestUtils.code;
 
 class ArrayExpressionImplTest extends BicepTreeModelTest {
@@ -34,6 +37,8 @@ class ArrayExpressionImplTest extends BicepTreeModelTest {
     ArmAssertions.assertThat(BicepLexicalGrammar.ARRAY_EXPRESSION)
       .matches(code("[", "]"))
       .matches(code("[", "'a'", "]"))
+      .matches(code("['a', 'b']"))
+      .matches(code("[", "'a', 'b'", "'c'", "]"))
       .matches(code("[", "'a'", "'b'", "]"))
       .matches(code("[", "    'a'", "    'b'", "]"))
       .matches(code("[", "", "", "   'a'", "", "    'b'", "]"))
@@ -47,13 +52,29 @@ class ArrayExpressionImplTest extends BicepTreeModelTest {
 
   @Test
   void shouldParseValidExpression() {
-    ArrayExpression tree = (ArrayExpression) createParser(BicepLexicalGrammar.ARRAY_EXPRESSION).parse(
-      code("[", "'a'", "'b'", "]"));
+    ArrayExpression tree = parse(code("[", "'a'", "'b'", "]"), BicepLexicalGrammar.ARRAY_EXPRESSION);
 
     SoftAssertions softly = new SoftAssertions();
     softly.assertThat(tree).isInstanceOf(ArrayExpression.class);
     softly.assertThat(tree.getKind()).isEqualTo(ArmTree.Kind.ARRAY_EXPRESSION);
     softly.assertThat(tree.elements()).hasSize(2);
     softly.assertAll();
+  }
+
+  @Test
+  void shouldParseMixedInlineAndMultilineArray() {
+    ArrayExpression tree = parse(code("[", "'a', 'b'", "'c'", "]"), BicepLexicalGrammar.ARRAY_EXPRESSION);
+
+    assertThat(tree.getKind()).isEqualTo(ArmTree.Kind.ARRAY_EXPRESSION);
+    assertThat(tree.elements()).hasSize(3);
+    StringComplete a = (StringComplete) tree.elements().get(0);
+    StringComplete b = (StringComplete) tree.elements().get(1);
+    StringComplete c = (StringComplete) tree.elements().get(2);
+    ArmAssertions.assertThat(a.content()).hasValue("a");
+    ArmAssertions.assertThat(b.content()).hasValue("b");
+    ArmAssertions.assertThat(c.content()).hasValue("c");
+
+    assertThat(recursiveTransformationOfTreeChildrenToStrings(tree))
+      .containsExactly("[", "a", ",", "b", "c", "]");
   }
 }

--- a/iac-extensions/arm/src/test/java/org/sonar/iac/arm/tree/impl/bicep/ArrayExpressionImplTest.java
+++ b/iac-extensions/arm/src/test/java/org/sonar/iac/arm/tree/impl/bicep/ArrayExpressionImplTest.java
@@ -63,7 +63,11 @@ class ArrayExpressionImplTest extends BicepTreeModelTest {
 
   @Test
   void shouldParseMixedInlineAndMultilineArray() {
-    ArrayExpression tree = parse(code("[", "'a', 'b'", "'c'", "]"), BicepLexicalGrammar.ARRAY_EXPRESSION);
+    String code = code("[",
+      "'a', 'b'",
+      "'c'",
+      "]");
+    ArrayExpression tree = parse(code, BicepLexicalGrammar.ARRAY_EXPRESSION);
 
     assertThat(tree.getKind()).isEqualTo(ArmTree.Kind.ARRAY_EXPRESSION);
     assertThat(tree.elements()).hasSize(3);


### PR DESCRIPTION
Bicep array value can either be specified alone on their line, or on a single line with comma separator.
```
array1 = [
  'a'
  'b'
]
array2 = ['c', 'd']
```
It also supports to mix those forms:
```
array_mix = [
  'a'
  'b'
  'c', 'd'
]
```

To enable this, I put SeparatedList in our `ArrayExpressionImpl`.
I modified `SeparatedList` to allow to store nullable value, which in the end get skipped when retrieving elements with separators.
This is done in order to keep the right order when retrieving the list of elements and separators in `children()` methods.
In the above last example, we would have those lists:
```
// list of element
['a', 'b', 'c', 'd']
// list of separator
[null, null, ',']
// when calling 'elementsAndSeparators'
elements = ['a', 'b', 'c', ',', 'd']
```