### PR TITLE
BUILD-3415 tasks must depend on build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -114,8 +114,8 @@ build_task:
   cleanup_before_cache_script: cleanup_maven_repository
 
 qa_os_win_task:
+  <<: *QA_TASK_FILTER
   <<: *WINDOWS_VM_DEFINITION
-  <<: *ONLY_IF_SONARSOURCE_QA
   maven_cache:
     #windows cache is buggy if using ${CIRRUS_WORKING_DIR}
     folder: ~/.m2/repository
@@ -124,6 +124,8 @@ qa_os_win_task:
     - mvn.cmd clean verify
 
 sca_scan_task:
+  depends_on:
+    - build
   <<: *LINUX_3_5_CPU_7G
   <<: *MAVEN_CACHE
   <<: *ONLY_MAIN_BRANCHES


### PR DESCRIPTION
Any task calling `source cirrus-env <TASK_TYPE>` with `TASK_TYPE!=BUILD*` must depend on the task calling `source cirrus-env BUILD`.

If you want to parallelize the build and the scan tasks, then you have to introduce a common root task to call `source cirrus-env BUILD` first, and then change the `<TASK_TYPE>` of the build task.
See https://github.com/SonarSource/re-ci-images/blob/master/docker/bin/cirrus-env#L24