### PR TITLE
SONARIAC-1169 Set up multi-architecture build on Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,6 +16,8 @@ env:
   # Allows to run builds for the 50 last commits in a branch:
   CIRRUS_CLONE_DEPTH: 1
 
+  GO_VERSION: 1.21.1
+
 maven_cache: &MAVEN_CACHE
   maven_cache:
     folder: ${CIRRUS_WORKING_DIR}/.m2/repository
@@ -113,18 +115,42 @@ qa_task_filter_template: &QA_TASK_FILTER
 # -------------------TASKS----------------------
 # ----------------------------------------------
 
+build_go_darwin_task:
+  container:
+    # Debian10 is required, because default image bundles too old macOS SDK for Go 1.21
+    image: docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-darwin-debian10
+  build_script:
+    - cd sonar-helm-for-iac
+    - /crossbuild --platforms="darwin/amd64" --build-cmd="bash make.sh build"
+  go_binaries_artifacts:
+    path: sonar-helm-for-iac/target/classes/sonar-helm-for-iac-*
+build_go_windows_task:
+  container:
+    image: docker.elastic.co/beats-dev/golang-crossbuild:${GO_VERSION}-main
+  build_script:
+    - cd sonar-helm-for-iac
+    - /crossbuild --platforms="windows/amd64" --build-cmd="bash make.sh build"
+  go_binaries_artifacts:
+    path: sonar-helm-for-iac/target/classes/sonar-helm-for-iac-*
+
 build_task:
   eks_container:
     <<: *LINUX_IMAGE_WITH_GCC
     cpu: 3.5
     memory: 7G
   <<: *MAVEN_CACHE
+  depends_on:
+    - build_go_darwin
+    - build_go_windows
   env:
     <<: *BUILD_SECRETS
     #allow deployment of pull request artifacts to repox
     DEPLOY_PULL_REQUEST: true
   build_script:
     - source cirrus-env BUILD
+    - curl -sL https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/go_binaries.zip -o go_binaries.zip
+    - mkdir -p sonar-helm-for-iac/target/classes/
+    - unzip -o go_binaries.zip -d . && rm go_binaries.zip
     - regular_mvn_build_deploy_analyze
   cleanup_before_cache_script: cleanup_maven_repository
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -150,7 +150,7 @@ build_task:
     - source cirrus-env BUILD
     - curl -sL https://api.cirrus-ci.com/v1/artifact/build/$CIRRUS_BUILD_ID/go_binaries.zip -o go_binaries.zip
     - mkdir -p sonar-helm-for-iac/target/classes/
-    - unzip -o go_binaries.zip -d . && rm go_binaries.zip
+    - unzip -o go_binaries.zip -d . && rm go_binaries.zip && find ./sonar-helm-for-iac/target/classes -name "*.h" -delete
     - regular_mvn_build_deploy_analyze
   cleanup_before_cache_script: cleanup_maven_repository
 

--- a/sonar-helm-for-iac/make.sh
+++ b/sonar-helm-for-iac/make.sh
@@ -109,7 +109,6 @@ compile_binaries() {
   if [ -n "${GOOS:-}" ]; then
     # GOOS is already set, so we perform build for it
     echo "Building for target OS: ${GOOS}"
-    go env
     case "${GOOS}" in
       "darwin")
         for GOARCH in amd64 arm64; do
@@ -130,9 +129,8 @@ compile_binaries() {
     GOOS=$(${path_to_binary} env GOOS)
     GOARCH=$(${path_to_binary} env GOARCH)
     echo "Building only for host architecture: ${GOOS}/${GOARCH}"
-    ${path_to_binary} env
     # Note: CGO_ENABLED will be set to 1 automatically if GOOS/GOARCH match the current system, but we set it explicitly for consistency.
-    CGO_ENABLED=1 ${path_to_binary} build -x -buildmode=c-shared -o target/classes/sonar-helm-for-iac-"$GOOS"-"$GOARCH"
+    CGO_ENABLED=1 ${path_to_binary} build -buildmode=c-shared -o target/classes/sonar-helm-for-iac-"$GOOS"-"$GOARCH"
   fi
 
   verifyLicenseHeader

--- a/sonar-helm-for-iac/make.sh
+++ b/sonar-helm-for-iac/make.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 set -euox pipefail
 
-readonly GO_VERSION="1.21.1"
+readonly GO_VERSION="${GO_VERSION:-1.21.1}"
 readonly DEFAULT_GO_BINARY_DIRECTORY="${GOPATH:=${HOME}/go}/bin"
 readonly DEFAULT_GO_BINARY="${DEFAULT_GO_BINARY_DIRECTORY}/go"
 
@@ -104,10 +104,34 @@ compile_binaries() {
   local path_to_binary
   path_to_binary=$(install_go "${GO_VERSION}")
 
-  GOOS=$(${path_to_binary} env GOOS)
-  GOARCH=$(${path_to_binary} env GOARCH)
-  echo "Building for architecture: ${GOOS}/${GOARCH}"
-  CGO_ENABLED=1 ${path_to_binary} build -o target/classes/sonar-helm-for-iac-"$GOOS"-"$GOARCH"
+  # Note: CGO_ENABLED is required to build with CGO, which is activated by `import "C"` in Go sources.
+  # Note: Saving files in target/classes include files in JAR out of the box.
+  if [ -n "${GOOS:-}" ]; then
+    # GOOS is already set, so we perform build for it
+    echo "Building for target OS: ${GOOS}"
+    case "${GOOS}" in
+      "darwin")
+        for GOARCH in amd64 arm64; do
+          CGO_ENABLED=1 go build -o target/classes/sonar-helm-for-iac-"${GOOS}"-"${GOARCH}"
+        done
+        ;;
+      "linux"|"windows")
+        GOARCH="amd64"
+        CGO_ENABLED=1 go build -o target/classes/sonar-helm-for-iac-"$GOOS"-"$GOARCH"
+        ;;
+      *)
+        echo "Unsupported GOOS: ${GOOS}"
+        exit 1
+        ;;
+    esac
+  else
+    # GOOS and GOARCH are not set, so we build for the host system.
+    GOOS=$(${path_to_binary} env GOOS)
+    GOARCH=$(${path_to_binary} env GOARCH)
+    echo "Building only for host architecture: ${GOOS}/${GOARCH}"
+    # Note: CGO_ENABLED will be set to 1 automatically if GOOS/GOARCH match the current system, but we set it explicitly for consistency.
+    CGO_ENABLED=1 ${path_to_binary} build -o target/classes/sonar-helm-for-iac-"$GOOS"-"$GOARCH"
+  fi
 
   verifyLicenseHeader
 }

--- a/sonar-helm-for-iac/make.sh
+++ b/sonar-helm-for-iac/make.sh
@@ -113,12 +113,12 @@ compile_binaries() {
     case "${GOOS}" in
       "darwin")
         for GOARCH in amd64 arm64; do
-          CGO_ENABLED=1 go build -x -o target/classes/sonar-helm-for-iac-"${GOOS}"-"${GOARCH}"
+          CGO_ENABLED=1 go build -buildmode=c-shared -o target/classes/sonar-helm-for-iac-"${GOOS}"-"${GOARCH}"
         done
         ;;
       "linux"|"windows")
         GOARCH="amd64"
-        CGO_ENABLED=1 go build -x -o target/classes/sonar-helm-for-iac-"$GOOS"-"$GOARCH"
+        CGO_ENABLED=1 go build -buildmode=c-shared -o target/classes/sonar-helm-for-iac-"$GOOS"-"$GOARCH"
         ;;
       *)
         echo "Unsupported GOOS: ${GOOS}"
@@ -132,7 +132,7 @@ compile_binaries() {
     echo "Building only for host architecture: ${GOOS}/${GOARCH}"
     ${path_to_binary} env
     # Note: CGO_ENABLED will be set to 1 automatically if GOOS/GOARCH match the current system, but we set it explicitly for consistency.
-    CGO_ENABLED=1 ${path_to_binary} build -x -o target/classes/sonar-helm-for-iac-"$GOOS"-"$GOARCH"
+    CGO_ENABLED=1 ${path_to_binary} build -x -buildmode=c-shared -o target/classes/sonar-helm-for-iac-"$GOOS"-"$GOARCH"
   fi
 
   verifyLicenseHeader

--- a/sonar-helm-for-iac/make.sh
+++ b/sonar-helm-for-iac/make.sh
@@ -109,15 +109,16 @@ compile_binaries() {
   if [ -n "${GOOS:-}" ]; then
     # GOOS is already set, so we perform build for it
     echo "Building for target OS: ${GOOS}"
+    go env
     case "${GOOS}" in
       "darwin")
         for GOARCH in amd64 arm64; do
-          CGO_ENABLED=1 go build -o target/classes/sonar-helm-for-iac-"${GOOS}"-"${GOARCH}"
+          CGO_ENABLED=1 go build -x -o target/classes/sonar-helm-for-iac-"${GOOS}"-"${GOARCH}"
         done
         ;;
       "linux"|"windows")
         GOARCH="amd64"
-        CGO_ENABLED=1 go build -o target/classes/sonar-helm-for-iac-"$GOOS"-"$GOARCH"
+        CGO_ENABLED=1 go build -x -o target/classes/sonar-helm-for-iac-"$GOOS"-"$GOARCH"
         ;;
       *)
         echo "Unsupported GOOS: ${GOOS}"
@@ -129,8 +130,9 @@ compile_binaries() {
     GOOS=$(${path_to_binary} env GOOS)
     GOARCH=$(${path_to_binary} env GOARCH)
     echo "Building only for host architecture: ${GOOS}/${GOARCH}"
+    ${path_to_binary} env
     # Note: CGO_ENABLED will be set to 1 automatically if GOOS/GOARCH match the current system, but we set it explicitly for consistency.
-    CGO_ENABLED=1 ${path_to_binary} build -o target/classes/sonar-helm-for-iac-"$GOOS"-"$GOARCH"
+    CGO_ENABLED=1 ${path_to_binary} build -x -o target/classes/sonar-helm-for-iac-"$GOOS"-"$GOARCH"
   fi
 
   verifyLicenseHeader

--- a/sonar-helm-for-iac/pom.xml
+++ b/sonar-helm-for-iac/pom.xml
@@ -41,6 +41,7 @@
               <arguments>
                 <argument>build</argument>
               </arguments>
+              <useMavenLogger>true</useMavenLogger>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
* Add two additional tasks that build Darwin and Windows artifacts inside `golang-crosscompile` containers and upload them as Cirrus artifacts
* Download these artifacts as part of build task; Linux binary is still being built as part of Maven build
* Change go buildmode to `c-shared`
* In `make.sh`, assume `GOOS` is unset on a developer machine (only set by `go` executable)