### PR TITLE
Wait for external process also after reading from it is finished

### DIFF
--- a/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/plugin/InstanceScopedHelmEvaluator.java
+++ b/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/plugin/InstanceScopedHelmEvaluator.java
@@ -27,7 +27,9 @@ import org.sonarsource.api.sonarlint.SonarLintSide;
 @ScannerSide
 @SonarLintSide(lifespan = SonarLintSide.INSTANCE)
 public class InstanceScopedHelmEvaluator extends HelmEvaluator {
+  private static final int PROCESS_TIMEOUT_MILLIS = 5_000;
+
   public InstanceScopedHelmEvaluator(TempFolder tempFolder) {
-    super(tempFolder.newDir());
+    super(tempFolder.newDir(), PROCESS_TIMEOUT_MILLIS);
   }
 }


### PR DESCRIPTION
Previous logic:
* Start a background thread that waits for 5 seconds for the process to finish and then kills it
* Perform IO exchange with the process

My hypothesis is that test may sometimes finish earlier than background thread kills the process of OS (Windows) releases all the resources after process exits. Hence junit is trying to delete an executable which is still in use by the OS.

New logic:
* Start background thread that waits for 5 seconds for the process to finish and then kills it
* Perform IO exchange with the process
* After it's done, wait for the process to finish from the main thread as well
 * If data is parsed w/o errors, but the process is forcibly killed from the background thread, don't throw an exception