### PR TITLE
SONARIAC-1271 Should not fail parsing unquoted text

### DIFF
--- a/iac-extensions/kubernetes/src/main/java/org/sonar/iac/helm/LineNumberCommentRemover.java
+++ b/iac-extensions/kubernetes/src/main/java/org/sonar/iac/helm/LineNumberCommentRemover.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
 import org.sonar.iac.common.extension.visitors.InputFileContext;
 import org.sonar.iac.kubernetes.visitors.LocationShifter;
 
-public class LineNumberCommentRemover {
+public final class LineNumberCommentRemover {
   private static final String NEW_LINE = "\\n\\r\\u2028\\u2029";
 
   private static final Pattern LINE_PATTERN = Pattern.compile("(?<lineContent>[^" + NEW_LINE + "]*+)(?<newLine>\\r\\n|[" + NEW_LINE + "])");

--- a/iac-extensions/kubernetes/src/main/java/org/sonar/iac/helm/LineNumberCommentRemover.java
+++ b/iac-extensions/kubernetes/src/main/java/org/sonar/iac/helm/LineNumberCommentRemover.java
@@ -31,6 +31,9 @@ public class LineNumberCommentRemover {
 
   private static final Pattern CONTAINS_LINE_NUMBER_OR_RANGE = Pattern.compile("#(?<rangeStart>\\d++)(:(?<rangeEnd>\\d++))?( #\\d++:?\\d*+)*+$");
 
+  private LineNumberCommentRemover() {
+  }
+
   /**
    * This method removes all comments that contains line numbers and store them in {@link LocationShifter}.
    * Also blank lines that contains only trailing line comment number are removed.

--- a/iac-extensions/kubernetes/src/main/java/org/sonar/iac/helm/LineNumberCommentRemover.java
+++ b/iac-extensions/kubernetes/src/main/java/org/sonar/iac/helm/LineNumberCommentRemover.java
@@ -1,0 +1,105 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.iac.helm;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+import org.sonar.iac.common.extension.visitors.InputFileContext;
+import org.sonar.iac.kubernetes.visitors.LocationShifter;
+
+public class LineNumberCommentRemover {
+  private static final String NEW_LINE = "\\n\\r\\u2028\\u2029";
+
+  private static final Pattern LINE_PATTERN = Pattern.compile("(?<lineContent>[^" + NEW_LINE + "]*+)(?<newLine>\\r\\n|[" + NEW_LINE + "])");
+
+  private static final Pattern CONTAINS_LINE_NUMBER_OR_RANGE = Pattern.compile("#(?<rangeStart>\\d++)(:(?<rangeEnd>\\d++))?( #\\d++:?\\d*+)*+$");
+
+  /**
+   * This method removes all comments that contains line numbers and store them in {@link LocationShifter}.
+   * Also blank lines that contains only trailing line comment number are removed.
+   * Such lines may be produced after evaluation of Helm template.
+   * In some cases such lines may cause parsing issues in snakeyaml-engine.
+   */
+  public static String cleanSource(String source, InputFileContext inputFileContext, LocationShifter locationShifter) {
+    var sb = new StringBuilder();
+    var matcher = LINE_PATTERN.matcher(source);
+
+    var lastIndex = 0;
+    var lineCounter = 1;
+    while (matcher.find()) {
+      var lineContent = matcher.group("lineContent");
+      var lineAndComment = toLineAndComment(lineContent);
+      if (!lineAndComment.contentWithoutComment.isBlank()) {
+        lineAndComment.addToLocationShifter(locationShifter, inputFileContext, lineCounter);
+        sb.append(lineAndComment.contentWithoutComment);
+        sb.append(matcher.group("newLine"));
+        lastIndex = matcher.end();
+        lineCounter++;
+      }
+    }
+    lineCounter++;
+    var lastLine = source.substring(lastIndex);
+    var lineAndComment = toLineAndComment(lastLine);
+    if (!lineAndComment.contentWithoutComment.isBlank()) {
+      sb.append(lineAndComment.contentWithoutComment);
+      lineAndComment.addToLocationShifter(locationShifter, inputFileContext, lineCounter);
+    }
+    return sb.toString();
+  }
+
+  private static LineAndComment toLineAndComment(String lineContent) {
+    var commentMatcher = CONTAINS_LINE_NUMBER_OR_RANGE.matcher(lineContent);
+    if (commentMatcher.find()) {
+      var comment = commentMatcher.group();
+      var endIndex = lineContent.indexOf(comment);
+      var lineContentWithoutComment = lineContent.substring(0, Math.max(endIndex - 1, 0));
+      var lineCommentRangeStart = Integer.parseInt(commentMatcher.group("rangeStart"));
+      var lineCommentRangeEnd = Optional.ofNullable(commentMatcher.group("rangeEnd"))
+        .map(Integer::parseInt)
+        .orElse(lineCommentRangeStart);
+      return new LineAndComment(lineContentWithoutComment, lineCommentRangeStart, lineCommentRangeEnd);
+    }
+    return new LineAndComment(lineContent);
+  }
+
+  private static class LineAndComment {
+    private final String contentWithoutComment;
+    private final Integer lineCommentRangeStart;
+    private final Integer lineCommentRangeEnd;
+
+    public LineAndComment(String contentWithoutComment) {
+      this.contentWithoutComment = contentWithoutComment;
+      lineCommentRangeStart = null;
+      lineCommentRangeEnd = null;
+    }
+
+    public LineAndComment(String contentWithoutComment, Integer lineCommentRangeStart, Integer lineCommentRangeEnd) {
+      this.contentWithoutComment = contentWithoutComment;
+      this.lineCommentRangeStart = lineCommentRangeStart;
+      this.lineCommentRangeEnd = lineCommentRangeEnd;
+    }
+
+    public void addToLocationShifter(LocationShifter locationShifter, InputFileContext inputFileContext, int lineCounter) {
+      if (lineCommentRangeStart != null && lineCommentRangeEnd != null) {
+        locationShifter.addShiftedLine(inputFileContext, lineCounter, lineCommentRangeStart, lineCommentRangeEnd);
+      }
+    }
+  }
+}

--- a/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/plugin/KubernetesParser.java
+++ b/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/plugin/KubernetesParser.java
@@ -45,8 +45,6 @@ public class KubernetesParser extends YamlParser {
   private static final Pattern HELM_DIRECTIVE_IN_COMMENT_OR_STRING = Pattern.compile("(" +
     String.join("|", DIRECTIVE_IN_COMMENT, DIRECTIVE_IN_SINGLE_QUOTE, DIRECTIVE_IN_DOUBLE_QUOTE, CODEFRESH_VARIABLES) + ")");
 
-  private static final String NEW_LINE = "\\n\\r\\u2028\\u2029";
-
   private final HelmProcessor helmProcessor;
   private final LocationShifter locationShifter;
 

--- a/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/plugin/KubernetesParser.java
+++ b/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/plugin/KubernetesParser.java
@@ -21,8 +21,6 @@ package org.sonar.iac.kubernetes.plugin;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.Optional;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.slf4j.Logger;
@@ -34,6 +32,7 @@ import org.sonar.iac.helm.utils.HelmFilesystemUtils;
 import org.sonar.iac.kubernetes.visitors.LocationShifter;
 
 import static org.sonar.iac.common.yaml.YamlFileUtils.splitLines;
+import static org.sonar.iac.helm.LineNumberCommentRemover.cleanSource;
 
 public class KubernetesParser extends YamlParser {
 
@@ -47,9 +46,6 @@ public class KubernetesParser extends YamlParser {
     String.join("|", DIRECTIVE_IN_COMMENT, DIRECTIVE_IN_SINGLE_QUOTE, DIRECTIVE_IN_DOUBLE_QUOTE, CODEFRESH_VARIABLES) + ")");
 
   private static final String NEW_LINE = "\\n\\r\\u2028\\u2029";
-  private static final Pattern LINE_PATTERN = Pattern.compile("(?<lineContent>[^" + NEW_LINE + "]*+)(?<newLine>\\r\\n|[" + NEW_LINE + "])");
-  private static final Pattern CONTAINS_LINE_NUMBER_OR_RANGE = Pattern.compile("#(?<rangeStart>\\d++)(:(?<rangeEnd>\\d++))?( #\\d++:?\\d*+)*+$");
-  private static final List<String> LINES_IGNORE_LINE_COUNTER = List.of("---", "...");
 
   private final HelmProcessor helmProcessor;
   private final LocationShifter locationShifter;
@@ -86,7 +82,7 @@ public class KubernetesParser extends YamlParser {
   private FileTree evaluateAndParseHelmFile(String source, InputFileContext inputFileContext) {
     var fileRelativePath = getFileRelativePath(inputFileContext);
     var evaluatedSource = helmProcessor.processHelmTemplate(fileRelativePath, source, inputFileContext);
-    var evaluatedAndCleanedSource = removeBlankLines(evaluatedSource, inputFileContext);
+    var evaluatedAndCleanedSource = cleanSource(evaluatedSource, inputFileContext, locationShifter);
     if (evaluatedAndCleanedSource.isBlank()) {
       LOG.debug("Blank evaluated file, skipping processing of Helm file {}", inputFileContext.inputFile);
       return super.parse("{}", null, FileTree.Template.HELM);
@@ -108,39 +104,6 @@ public class KubernetesParser extends YamlParser {
     return fileRelativePath;
   }
 
-  /**
-   * This method remove blank lines that contains only trailing line comment number.
-   * Also lines like {@code --- #5} or {@code ... #5} are added without comment.
-   * Such lines may be produced after evaluation of Helm template.
-   * In some cases such lines may cause parsing issues in snakeyaml-engine.
-   */
-  private String removeBlankLines(String source, InputFileContext inputFileContext) {
-    var sb = new StringBuilder();
-    var matcher = LINE_PATTERN.matcher(source);
-
-    var lastIndex = 0;
-    var lineCounter = 1;
-    while (matcher.find()) {
-      var lineContent = matcher.group("lineContent");
-      var lineAndComment = toLineAndComment(lineContent);
-      if (!lineAndComment.contentWithoutComment.isBlank()) {
-        lineAndComment.addToLocationShifter(locationShifter, inputFileContext, lineCounter);
-        sb.append(lineAndComment.contentWithoutComment);
-        sb.append(matcher.group("newLine"));
-        lastIndex = matcher.end();
-        lineCounter++;
-      }
-    }
-    lineCounter++;
-    var lastLine = source.substring(lastIndex);
-    var lineAndComment = toLineAndComment(lastLine);
-    if (!lineAndComment.contentWithoutComment.isBlank()) {
-      sb.append(lineAndComment.contentWithoutComment);
-      lineAndComment.addToLocationShifter(locationShifter, inputFileContext, lineCounter);
-    }
-    return sb.toString();
-  }
-
   public static boolean hasHelmContent(String text) {
     String[] lines = splitLines(text);
     for (String line : lines) {
@@ -153,44 +116,5 @@ public class KubernetesParser extends YamlParser {
 
   public static boolean hasHelmContentInLine(String line) {
     return line.contains("{{") && !HELM_DIRECTIVE_IN_COMMENT_OR_STRING.matcher(line).find();
-  }
-
-  private static LineAndComment toLineAndComment(String lineContent) {
-    var commentMatcher = CONTAINS_LINE_NUMBER_OR_RANGE.matcher(lineContent);
-    if (commentMatcher.find()) {
-      var comment = commentMatcher.group();
-      var endIndex = lineContent.indexOf(comment);
-      var lineContentWithoutComment = lineContent.substring(0, Math.max(endIndex - 1, 0));
-      var lineCommentRangeStart = Integer.parseInt(commentMatcher.group("rangeStart"));
-      var lineCommentRangeEnd = Optional.ofNullable(commentMatcher.group("rangeEnd"))
-        .map(Integer::parseInt)
-        .orElse(lineCommentRangeStart);
-      return new LineAndComment(lineContentWithoutComment, lineCommentRangeStart, lineCommentRangeEnd);
-    }
-    return new LineAndComment(lineContent);
-  }
-
-  private static class LineAndComment {
-    private final String contentWithoutComment;
-    private final Integer lineCommentRangeStart;
-    private final Integer lineCommentRangeEnd;
-
-    public LineAndComment(String contentWithoutComment) {
-      this.contentWithoutComment = contentWithoutComment;
-      lineCommentRangeStart = null;
-      lineCommentRangeEnd = null;
-    }
-
-    public LineAndComment(String contentWithoutComment, Integer lineCommentRangeStart, Integer lineCommentRangeEnd) {
-      this.contentWithoutComment = contentWithoutComment;
-      this.lineCommentRangeStart = lineCommentRangeStart;
-      this.lineCommentRangeEnd = lineCommentRangeEnd;
-    }
-
-    public void addToLocationShifter(LocationShifter locationShifter, InputFileContext inputFileContext, int lineCounter) {
-      if (lineCommentRangeStart != null && lineCommentRangeEnd != null) {
-        locationShifter.addShiftedLine(inputFileContext, lineCounter, lineCommentRangeStart, lineCommentRangeEnd);
-      }
-    }
   }
 }

--- a/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/plugin/KubernetesParser.java
+++ b/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/plugin/KubernetesParser.java
@@ -119,34 +119,24 @@ public class KubernetesParser extends YamlParser {
     var matcher = LINE_PATTERN.matcher(source);
 
     var lastIndex = 0;
-    var lineCounter = 0;
+    var lineCounter = 1;
     while (matcher.find()) {
       var lineContent = matcher.group("lineContent");
       var lineAndComment = toLineAndComment(lineContent);
       if (!lineAndComment.contentWithoutComment.isBlank()) {
-        if (LINES_IGNORE_LINE_COUNTER.contains(lineAndComment.contentWithoutComment)) {
-          sb.append(lineAndComment.contentWithoutComment);
-          lineAndComment.addToLocationShifter(locationShifter, inputFileContext, lineCounter);
-        } else {
-          sb.append(lineContent);
-        }
+        lineAndComment.addToLocationShifter(locationShifter, inputFileContext, lineCounter);
+        sb.append(lineAndComment.contentWithoutComment);
         sb.append(matcher.group("newLine"));
         lastIndex = matcher.end();
-      } else {
-        lineAndComment.addToLocationShifter(locationShifter, inputFileContext, lineCounter);
+        lineCounter++;
       }
-      lineCounter++;
     }
     lineCounter++;
     var lastLine = source.substring(lastIndex);
     var lineAndComment = toLineAndComment(lastLine);
     if (!lineAndComment.contentWithoutComment.isBlank()) {
-      if (LINES_IGNORE_LINE_COUNTER.contains(lineAndComment.contentWithoutComment)) {
-        sb.append(lineAndComment.contentWithoutComment);
-        lineAndComment.addToLocationShifter(locationShifter, inputFileContext, lineCounter);
-      } else {
-        sb.append(lastLine);
-      }
+      sb.append(lineAndComment.contentWithoutComment);
+      lineAndComment.addToLocationShifter(locationShifter, inputFileContext, lineCounter);
     }
     return sb.toString();
   }

--- a/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/visitors/CommentLocationVisitor.java
+++ b/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/visitors/CommentLocationVisitor.java
@@ -53,7 +53,7 @@ public class CommentLocationVisitor extends TreeVisitor<InputFileContext> {
   }
 
   private void initialize() {
-    register(YamlTree.class, this::visitComment);
+//    register(YamlTree.class, this::visitComment);
   }
 
   @Override
@@ -85,19 +85,19 @@ public class CommentLocationVisitor extends TreeVisitor<InputFileContext> {
     }
   }
 
-  public void visitComment(InputFileContext ctx, YamlTree tree) {
-    tree.metadata().comments().forEach(comment -> processComment(ctx, comment));
-  }
+//  public void visitComment(InputFileContext ctx, YamlTree tree) {
+//    tree.metadata().comments().forEach(comment -> processComment(ctx, comment));
+//  }
 
-  private void processComment(InputFileContext ctx, Comment comment) {
-    var matcher = CONTAINS_LINE_NUMBER_OR_RANGE.matcher(comment.value());
-    if (matcher.find()) {
-      int lineCommentLocation = comment.textRange().start().line();
-      var lineCommentRangeStart = Integer.parseInt(matcher.group("rangeStart"));
-      var lineCommentRangeEnd = Optional.ofNullable(matcher.group("rangeEnd")).map(Integer::parseInt).orElse(lineCommentRangeStart);
-      shifter.addShiftedLine(ctx, lineCommentLocation, lineCommentRangeStart, lineCommentRangeEnd);
-    } else {
-      LOG.debug("Line number comment not detected, comment: {}", comment.value());
-    }
-  }
+//  private void processComment(InputFileContext ctx, Comment comment) {
+//    var matcher = CONTAINS_LINE_NUMBER_OR_RANGE.matcher(comment.value());
+//    if (matcher.find()) {
+//      int lineCommentLocation = comment.textRange().start().line();
+//      var lineCommentRangeStart = Integer.parseInt(matcher.group("rangeStart"));
+//      var lineCommentRangeEnd = Optional.ofNullable(matcher.group("rangeEnd")).map(Integer::parseInt).orElse(lineCommentRangeStart);
+//      shifter.addShiftedLine(ctx, lineCommentLocation, lineCommentRangeStart, lineCommentRangeEnd);
+//    } else {
+//      LOG.debug("Line number comment not detected, comment: {}", comment.value());
+//    }
+//  }
 }

--- a/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/visitors/CommentLocationVisitor.java
+++ b/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/visitors/CommentLocationVisitor.java
@@ -53,7 +53,7 @@ public class CommentLocationVisitor extends TreeVisitor<InputFileContext> {
   }
 
   private void initialize() {
-     register(YamlTree.class, this::visitComment);
+    register(YamlTree.class, this::visitComment);
   }
 
   @Override

--- a/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/visitors/CommentLocationVisitor.java
+++ b/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/visitors/CommentLocationVisitor.java
@@ -53,7 +53,7 @@ public class CommentLocationVisitor extends TreeVisitor<InputFileContext> {
   }
 
   private void initialize() {
-//    register(YamlTree.class, this::visitComment);
+     register(YamlTree.class, this::visitComment);
   }
 
   @Override
@@ -85,19 +85,19 @@ public class CommentLocationVisitor extends TreeVisitor<InputFileContext> {
     }
   }
 
-//  public void visitComment(InputFileContext ctx, YamlTree tree) {
-//    tree.metadata().comments().forEach(comment -> processComment(ctx, comment));
-//  }
+  public void visitComment(InputFileContext ctx, YamlTree tree) {
+    tree.metadata().comments().forEach(comment -> processComment(ctx, comment));
+  }
 
-//  private void processComment(InputFileContext ctx, Comment comment) {
-//    var matcher = CONTAINS_LINE_NUMBER_OR_RANGE.matcher(comment.value());
-//    if (matcher.find()) {
-//      int lineCommentLocation = comment.textRange().start().line();
-//      var lineCommentRangeStart = Integer.parseInt(matcher.group("rangeStart"));
-//      var lineCommentRangeEnd = Optional.ofNullable(matcher.group("rangeEnd")).map(Integer::parseInt).orElse(lineCommentRangeStart);
-//      shifter.addShiftedLine(ctx, lineCommentLocation, lineCommentRangeStart, lineCommentRangeEnd);
-//    } else {
-//      LOG.debug("Line number comment not detected, comment: {}", comment.value());
-//    }
-//  }
+  private void processComment(InputFileContext ctx, Comment comment) {
+    var matcher = CONTAINS_LINE_NUMBER_OR_RANGE.matcher(comment.value());
+    if (matcher.find()) {
+      int lineCommentLocation = comment.textRange().start().line();
+      var lineCommentRangeStart = Integer.parseInt(matcher.group("rangeStart"));
+      var lineCommentRangeEnd = Optional.ofNullable(matcher.group("rangeEnd")).map(Integer::parseInt).orElse(lineCommentRangeStart);
+      shifter.addShiftedLine(ctx, lineCommentLocation, lineCommentRangeStart, lineCommentRangeEnd);
+    } else {
+      LOG.debug("Line number comment not detected, comment: {}", comment.value());
+    }
+  }
 }

--- a/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/visitors/LocationShifter.java
+++ b/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/visitors/LocationShifter.java
@@ -44,10 +44,7 @@ public class LocationShifter {
   private final Map<URI, LinesShifting> linesShiftingPerContext = new HashMap<>();
 
   public void addShiftedLine(InputFileContext ctx, int transformedLine, int targetLine) {
-    var shifting = getOrCreateLinesShifting(ctx);
-    var linesData = shifting.getOrCreateLinesData(transformedLine);
-    linesData.targetStartLine = targetLine;
-    linesData.targetEndLine = targetLine;
+    addShiftedLine(ctx, transformedLine, targetLine, targetLine);
   }
 
   public void addShiftedLine(InputFileContext ctx, int transformedLine, int targetStartLine, int targetEndLine) {
@@ -105,8 +102,8 @@ public class LocationShifter {
     var rangeEnd = endLineData
       .map(p -> p.targetEndLine)
       .orElse(shifting.getLastOriginalLine());
-    var rangeEndLineLength = getOrCreateLinesShifting(ctx).originalLinesSizes.get(rangeEnd);
-    var end = new TextPointer(rangeEnd, Math.min(textRange.end().lineOffset(), rangeEndLineLength));
+    var rangeEndLineLength = getOrCreateLinesShifting(ctx).originalLinesSizes.getOrDefault(rangeEnd, 0);
+    var end = new TextPointer(rangeEnd, rangeEndLineLength);
 
     return new TextRange(start, end);
   }
@@ -121,7 +118,15 @@ public class LocationShifter {
    * The original line length and target line number are stored in the value, as a {@link LineData} object.
    */
   static class LinesShifting {
+
+    /**
+     * The key is line number 1-based - first line number is 1.
+     */
     private final Map<Integer, LineData> linesData = new TreeMap<>();
+
+    /**
+     * The key is line number 1-based - first line number is 1.
+     */
     private final Map<Integer, Integer> originalLinesSizes = new HashMap<>();
 
     private LineData getOrCreateLinesData(Integer lineNumber) {

--- a/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/visitors/LocationShifter.java
+++ b/iac-extensions/kubernetes/src/main/java/org/sonar/iac/kubernetes/visitors/LocationShifter.java
@@ -48,7 +48,6 @@ public class LocationShifter {
     var linesData = shifting.getOrCreateLinesData(transformedLine);
     linesData.targetStartLine = targetLine;
     linesData.targetEndLine = targetLine;
-    linesData.originalLineSize = shifting.originalLinesSizes.getOrDefault(targetLine, 0);
   }
 
   public void addShiftedLine(InputFileContext ctx, int transformedLine, int targetStartLine, int targetEndLine) {
@@ -56,7 +55,6 @@ public class LocationShifter {
     var linesData = shifting.getOrCreateLinesData(transformedLine);
     linesData.targetStartLine = targetStartLine;
     linesData.targetEndLine = targetEndLine;
-    linesData.originalLineSize = shifting.originalLinesSizes.getOrDefault(targetEndLine, 0);
   }
 
   public void addLineSize(InputFileContext ctx, int originalLine, int size) {
@@ -107,9 +105,8 @@ public class LocationShifter {
     var rangeEnd = endLineData
       .map(p -> p.targetEndLine)
       .orElse(shifting.getLastOriginalLine());
-    var end = new TextPointer(rangeEnd,
-      endLineData.map(p -> p.originalLineSize)
-        .orElse(shifting.originalLinesSizes.getOrDefault(shifting.getLastOriginalLine(), 0)));
+    var rangeEndLineLength = getOrCreateLinesShifting(ctx).originalLinesSizes.get(rangeEnd);
+    var end = new TextPointer(rangeEnd, Math.min(textRange.end().lineOffset(), rangeEndLineLength));
 
     return new TextRange(start, end);
   }
@@ -150,6 +147,5 @@ public class LocationShifter {
   static class LineData {
     private Integer targetStartLine;
     private Integer targetEndLine;
-    private int originalLineSize;
   }
 }

--- a/iac-extensions/kubernetes/src/test/java/org/sonar/iac/helm/LineNumberCommentRemoverTest.java
+++ b/iac-extensions/kubernetes/src/test/java/org/sonar/iac/helm/LineNumberCommentRemoverTest.java
@@ -1,0 +1,200 @@
+/*
+ * SonarQube IaC Plugin
+ * Copyright (C) 2021-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.iac.helm;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sonar.api.batch.fs.FileSystem;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.internal.predicates.DefaultFilePredicates;
+import org.sonar.api.batch.sensor.SensorContext;
+import org.sonar.iac.common.api.tree.impl.TextPointer;
+import org.sonar.iac.common.api.tree.impl.TextRange;
+import org.sonar.iac.common.extension.visitors.InputFileContext;
+import org.sonar.iac.kubernetes.visitors.LocationShifter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.sonar.iac.common.testing.IacCommonAssertions.assertThat;
+import static org.sonar.iac.common.testing.IacTestUtils.code;
+
+class LineNumberCommentRemoverTest {
+  private final InputFile inputFile = mock(InputFile.class);
+  private final SensorContext sensorContext = mock(SensorContext.class);
+  private final InputFileContext inputFileContext = new InputFileContext(sensorContext, inputFile);
+
+  private LocationShifter locationShifter;
+
+  @BeforeEach
+  void setup() throws URISyntaxException {
+    var fs = mock(FileSystem.class);
+    when(sensorContext.fileSystem()).thenReturn(fs);
+    when(fs.predicates()).thenReturn(new DefaultFilePredicates(Path.of(".")));
+    when(inputFile.filename()).thenReturn("foo.yaml");
+    when(inputFile.toString()).thenReturn("chart/templates/foo.yaml");
+    when(inputFile.uri()).thenReturn(new URI("file:///chart/templates/foo.yaml"));
+    locationShifter = new LocationShifter();
+  }
+
+  @Test
+  void shouldRemoveEmptyLinesAfterEvaluation() {
+    String evaluated = code(
+      "apiVersion: apps/v1 #1",
+      "kind: StatefulSet #2",
+      "metadata: #3",
+      "  name: helm-chart-sonarqube-dce-search #4",
+      "spec: #5",
+      "  livenessProbe: #6",
+      "    exec: #7",
+      "      command: #8",
+      "        - sh #9",
+      "        - -c #10",
+      "        #14",
+      "        - | #15",
+      "          bar #16 #17",
+      "    initialDelaySeconds: 60 #18",
+      "  #19");
+    var expected = code(
+      "apiVersion: apps/v1",
+      "kind: StatefulSet",
+      "metadata:",
+      "  name: helm-chart-sonarqube-dce-search",
+      "spec:",
+      "  livenessProbe:",
+      "    exec:",
+      "      command:",
+      "        - sh",
+      "        - -c",
+      "        - |",
+      "          bar",
+      "    initialDelaySeconds: 60",
+      "");
+    var actual = cleanSource(evaluated);
+
+    assertThat(actual).isEqualTo(expected);
+
+    assertLineMapping(
+      1, 1,
+      10, 10,
+      11, 15,
+      12, 16,
+      13, 18);
+  }
+
+  @Test
+  void shouldRemoveNewDocumentAfterEvaluation() {
+    var evaluated = code(
+      "--- #5",
+      "apiVersion: v1 #6",
+      "kind: Pod #7",
+      "metadata: #8",
+      "spec: #9");
+    var expected = code(
+      "---",
+      "apiVersion: v1",
+      "kind: Pod",
+      "metadata:",
+      "spec:");
+    var actual = cleanSource(evaluated);
+
+    assertThat(actual).isEqualTo(expected);
+
+    assertLineMapping(
+      1, 5,
+      2, 6,
+      3, 7,
+      4, 8,
+      5, 9);
+  }
+
+  @Test
+  void shouldRemoveLineNumberCommentForNewDocumentAtEndAfterEvaluation() {
+    var evaluated = code(
+      "apiVersion: v1 #6",
+      "kind: Pod #7",
+      "metadata: #8",
+      "spec: #9",
+      "--- #12");
+    var expected = code(
+      "apiVersion: v1",
+      "kind: Pod",
+      "metadata:",
+      "spec:",
+      "---");
+    var actual = cleanSource(evaluated);
+
+    assertThat(actual).isEqualTo(expected);
+
+    assertLineMapping(
+      1, 6,
+      2, 7,
+      3, 8,
+      4, 9,
+      5, 12);
+  }
+
+  @Test
+  void shouldRemoveLineNumberCommentForEndDocumentAfterEvaluation() {
+    var evaluated = code(
+      "apiVersion: v1 #6",
+      "kind: Pod #7",
+      "metadata: #8",
+      "spec: #9",
+      "... #10");
+    var expected = code(
+      "apiVersion: v1",
+      "kind: Pod",
+      "metadata:",
+      "spec:",
+      "...");
+    var actual = cleanSource(evaluated);
+
+    assertThat(actual).isEqualTo(expected);
+
+    assertLineMapping(
+      1, 6,
+      2, 7,
+      3, 8,
+      4, 9,
+      5, 10);
+  }
+
+  private String cleanSource(String evaluated) {
+    return LineNumberCommentRemover.cleanSource(evaluated, inputFileContext, locationShifter);
+  }
+
+  private void assertLineMapping(int... numbers) {
+    if (numbers.length % 2 == 1) {
+      throw new RuntimeException("The even number of arguments is expected");
+    }
+    for (int i = 0; i < numbers.length; i = i + 2) {
+      var textRange = getComputeShiftedLocation(numbers[i], 0, numbers[i], 0);
+      assertThat(textRange).hasRange(numbers[i + 1], 0, numbers[i + 1], 0);
+    }
+  }
+
+  private TextRange getComputeShiftedLocation(int startLine, int startLineOffset, int endLine, int endLineOffset) {
+    return locationShifter.computeShiftedLocation(inputFileContext, new TextRange(new TextPointer(startLine, startLineOffset), new TextPointer(endLine, endLineOffset)));
+  }
+}

--- a/iac-extensions/kubernetes/src/test/java/org/sonar/iac/kubernetes/plugin/KubernetesParserTest.java
+++ b/iac-extensions/kubernetes/src/test/java/org/sonar/iac/kubernetes/plugin/KubernetesParserTest.java
@@ -247,7 +247,7 @@ class KubernetesParserTest {
       "kind: Pod #7",
       "metadata: #8",
       "spec: #9",
-      "... #12");
+      "--- #12");
     try (var ignored = Mockito.mockStatic(HelmFilesystemUtils.class)) {
       var valuesFile = mock(InputFile.class);
       when(valuesFile.filename()).thenReturn("values.yaml");

--- a/iac-extensions/kubernetes/src/test/java/org/sonar/iac/kubernetes/plugin/KubernetesSensorTest.java
+++ b/iac-extensions/kubernetes/src/test/java/org/sonar/iac/kubernetes/plugin/KubernetesSensorTest.java
@@ -378,7 +378,7 @@ class KubernetesSensorTest extends ExtensionSensorTest {
       }
       var last = lines[endLine - 1].substring(0, textRange.end().lineOffset());
       sb.append(last);
-      assertThat(sb.toString()).isEqualTo(expectedText);
+      assertThat(sb).hasToString(expectedText);
     }
   }
 

--- a/iac-extensions/kubernetes/src/test/java/org/sonar/iac/kubernetes/plugin/KubernetesSensorTest.java
+++ b/iac-extensions/kubernetes/src/test/java/org/sonar/iac/kubernetes/plugin/KubernetesSensorTest.java
@@ -315,11 +315,13 @@ class KubernetesSensorTest extends ExtensionSensorTest {
     Issue issue = context.allIssues().iterator().next();
     assertThat(issue.primaryLocation().message()).isEqualTo("Primary message");
     TextRange textRange = issue.primaryLocation().textRange();
+    assertTextRange(textRange, originalSourceCode, "{{ some helm code }}");
     assertTextRange(textRange, 4, 0, 4, 20);
 
     assertThat(issue.flows()).hasSize(1);
     Issue.Flow flow1 = issue.flows().get(0);
     assertSecondaryLocation(flow1, 5, 0, 5, 26, "Secondary message");
+    assertTextRange(flow1.locations().get(0).textRange(), originalSourceCode, "{{ some other helm code }}");
   }
 
   @Test
@@ -357,6 +359,27 @@ class KubernetesSensorTest extends ExtensionSensorTest {
     assertThat(textRange.start().lineOffset()).isEqualTo(startLineOffset);
     assertThat(textRange.end().line()).isEqualTo(endLine);
     assertThat(textRange.end().lineOffset()).isEqualTo(endLineOffset);
+  }
+
+  private void assertTextRange(@Nullable TextRange textRange, String input, String expectedText) {
+    var lines = input.split("\n");
+    assertThat(textRange).isNotNull();
+    var startLine = textRange.start().line();
+    var endLine = textRange.end().line();
+    if (startLine == endLine) {
+      var actual = lines[startLine - 1].substring(textRange.start().lineOffset(), textRange.end().lineOffset());
+      assertThat(actual).isEqualTo(expectedText);
+    } else {
+      var sb = new StringBuilder();
+      var first = lines[startLine - 1].substring(textRange.start().lineOffset(), textRange.end().lineOffset());
+      sb.append(first);
+      for (int i = startLine + 1; i < endLine; i++) {
+        sb.append(lines[i - 1]);
+      }
+      var last = lines[endLine - 1].substring(0, textRange.end().lineOffset());
+      sb.append(last);
+      assertThat(sb.toString()).isEqualTo(expectedText);
+    }
   }
 
   private void assertSecondaryLocation(Issue.Flow flow, int startLine, int startLineOffset, int endLine, int endLineOffset, String message) {

--- a/iac-extensions/kubernetes/src/test/java/org/sonar/iac/kubernetes/visitors/LocationShifterTest.java
+++ b/iac-extensions/kubernetes/src/test/java/org/sonar/iac/kubernetes/visitors/LocationShifterTest.java
@@ -31,7 +31,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.sonar.iac.common.testing.TextRangeAssert.assertThat;
 
-class LocationShifterTest {
+final class LocationShifterTest {
 
   private final LocationShifter shifter = new LocationShifter();
   private final InputFileContext ctx = mockInputFileContext("my_uri");

--- a/its/ruling/src/integrationTest/resources/expected/kubernetes/kubernetes-S2260.json
+++ b/its/ruling/src/integrationTest/resources/expected/kubernetes/kubernetes-S2260.json
@@ -32,9 +32,6 @@
 "kubernetes-project:sources/kubernetes/helm-chart-sonarqube/charts/sonarqube-dce/templates/install-plugins.yaml": [
 12
 ],
-"kubernetes-project:sources/kubernetes/helm-chart-sonarqube/charts/sonarqube-dce/templates/tests/sonarqube-test.yaml": [
-0
-],
 "kubernetes-project:sources/kubernetes/helm-chart-sonarqube/charts/sonarqube/templates/config.yaml": [
 12
 ],
@@ -43,8 +40,5 @@
 ],
 "kubernetes-project:sources/kubernetes/helm-chart-sonarqube/charts/sonarqube/templates/install-plugins.yaml": [
 12
-],
-"kubernetes-project:sources/kubernetes/helm-chart-sonarqube/charts/sonarqube/templates/tests/sonarqube-test.yaml": [
-0
 ]
 }

--- a/its/ruling/src/integrationTest/resources/expected/kubernetes/kubernetes-S5849.json
+++ b/its/ruling/src/integrationTest/resources/expected/kubernetes/kubernetes-S5849.json
@@ -11,6 +11,9 @@
 "kubernetes-project:ruling/src/integrationTest/resources/sources/kubernetes/helm/corner-cases/templates/empty-line-end.yaml": [
 12
 ],
+"kubernetes-project:ruling/src/integrationTest/resources/sources/kubernetes/helm/corner-cases/templates/multiline-string.yaml": [
+15
+],
 "kubernetes-project:ruling/src/integrationTest/resources/sources/kubernetes/helm/corner-cases/templates/multiple-documents.yaml": [
 11,
 27,

--- a/its/ruling/src/integrationTest/resources/expected/kubernetes/kubernetes-S6864.json
+++ b/its/ruling/src/integrationTest/resources/expected/kubernetes/kubernetes-S6864.json
@@ -23,6 +23,9 @@
 "kubernetes-project:ruling/src/integrationTest/resources/sources/kubernetes/helm/corner-cases/templates/empty-line-end.yaml": [
 7
 ],
+"kubernetes-project:ruling/src/integrationTest/resources/sources/kubernetes/helm/corner-cases/templates/multiline-string.yaml": [
+11
+],
 "kubernetes-project:ruling/src/integrationTest/resources/sources/kubernetes/helm/corner-cases/templates/multiline-templates.yaml": [
 16
 ],
@@ -378,5 +381,11 @@
 ],
 "kubernetes-project:sources/kubernetes/examples/volumes/storageos/storageos-sc-pvcpod.yaml": [
 10
+],
+"kubernetes-project:sources/kubernetes/helm-chart-sonarqube/charts/sonarqube-dce/templates/tests/sonarqube-test.yaml": [
+24
+],
+"kubernetes-project:sources/kubernetes/helm-chart-sonarqube/charts/sonarqube/templates/tests/sonarqube-test.yaml": [
+24
 ]
 }

--- a/its/ruling/src/integrationTest/resources/expected/kubernetes/kubernetes-S6869.json
+++ b/its/ruling/src/integrationTest/resources/expected/kubernetes/kubernetes-S6869.json
@@ -23,6 +23,9 @@
 "kubernetes-project:ruling/src/integrationTest/resources/sources/kubernetes/helm/corner-cases/templates/empty-line-end.yaml": [
 7
 ],
+"kubernetes-project:ruling/src/integrationTest/resources/sources/kubernetes/helm/corner-cases/templates/multiline-string.yaml": [
+11
+],
 "kubernetes-project:ruling/src/integrationTest/resources/sources/kubernetes/helm/corner-cases/templates/multiline-templates.yaml": [
 16
 ],
@@ -353,5 +356,11 @@
 ],
 "kubernetes-project:sources/kubernetes/examples/volumes/rbd/rbd.yaml": [
 7
+],
+"kubernetes-project:sources/kubernetes/helm-chart-sonarqube/charts/sonarqube-dce/templates/tests/sonarqube-test.yaml": [
+24
+],
+"kubernetes-project:sources/kubernetes/helm-chart-sonarqube/charts/sonarqube/templates/tests/sonarqube-test.yaml": [
+24
 ]
 }

--- a/its/ruling/src/integrationTest/resources/sources/kubernetes/helm/corner-cases/templates/multiline-string.yaml
+++ b/its/ruling/src/integrationTest/resources/sources/kubernetes/helm/corner-cases/templates/multiline-string.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example
+  description: Some text without double quotes
+  description2: multiline
+    unquoted
+    description
+spec:
+  containers:
+    - image: k8s.gcr.io/test-webserver
+      name: test-container
+      securityContext:
+        capabilities:
+          add:
+{{- range .Values.capabilities }}
+            - {{ . | quote }}
+{{- end }}


### PR DESCRIPTION
When `CommentLocationVisitor.visitComment()` is "deactivated", the ruling tests are also green. But removing this code will be in the scope of a separate ticket: SONARIAC-1277