### PR TITLE
Use a more powerful machine for Windows builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -85,8 +85,9 @@ win_vm_definition: &WINDOWS_VM_DEFINITION
     image: base-windows-jdk17-v*
     platform: windows
     region: eu-central-1
-    type: t3.xlarge
+    type: c5.4xlarge # 3.6 GHz (3.9GHz single core) Intel Xeon Scalable Processor, 16 vCPU, 32 GiB Memory
     subnet_id: ${CIRRUS_AWS_SUBNET}
+    preemptible: false
     use_ssd: true
 
 # ----------------------------------------------


### PR DESCRIPTION
Reduces pure Windows build time from 8:20 to 4:30. That reduces the CI time from ~15 min to 11 min