### PR TITLE
Fix incorrect versions of some GH actions

### DIFF
--- a/.github/workflows/dogfood.yml
+++ b/.github/workflows/dogfood.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: get secrets
         id: secrets
-        uses: SonarSource/vault-action-wrapper@2
+        uses: SonarSource/vault-action-wrapper@2.8.0
         with:
           secrets: |
             development/kv/data/slack webhook | SLACK_WEBHOOK;
@@ -36,14 +36,14 @@ jobs:
         run: echo "The dogfood branch was `${{ steps.dogfood.outputs.dogfood-branch }}` and its HEAD SHA1 was `${{ steps.dogfood.outputs.sha1 }}`"
       #slack notifications
       - name: Notify success on Slack
-        uses: Ilshidur/action-slack@2
+        uses: Ilshidur/action-slack@2.1.0
         env:
           SLACK_WEBHOOK: ${{ fromJSON(steps.secrets.outputs.vault).SLACK_WEBHOOK }}
           SLACK_OVERRIDE_MESSAGE: 'Dogfood build for `${{ steps.dogfood.outputs.sha1 }}`: *successful*'
         with:
           args: 'Succeed to build dogfood branch'
       - name: Notify failures on Slack
-        uses: Ilshidur/action-slack@2
+        uses: Ilshidur/action-slack@2.1.0
         if: failure()
         env:
           SLACK_WEBHOOK: ${{ fromJSON(steps.secrets.outputs.vault).SLACK_WEBHOOK }}

--- a/.github/workflows/releasability-check.yml
+++ b/.github/workflows/releasability-check.yml
@@ -13,6 +13,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/releasability-check.yaml@5
+    uses: SonarSource/gh-action_release/.github/workflows/releasability-check.yaml@v5
     with:
       version: ${{ github.event.inputs.version }}


### PR DESCRIPTION
Apparently, I was wrong and Github doesn't process versions itself:
```
If the action publishes major version tags, you should expect to receive critical fixes and security patches while still retaining compatibility. Note that this behavior is at the discretion of the action's author.
```
([source](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses))

I checked the actions we use and fixed nonexistent tags.