### PR TITLE
Update sonar-formatter to version 23

### DIFF
--- a/build-logic/src/main/kotlin/org.sonarsource.iac.code-style-convention.gradle.kts
+++ b/build-logic/src/main/kotlin/org.sonarsource.iac.code-style-convention.gradle.kts
@@ -7,10 +7,12 @@ plugins {
 spotless {
     encoding(Charsets.UTF_8)
     java {
+        // point to immutable specific commit of sonar-formater.xml version 23
         eclipse("4.22")
             .configFile(
                 Blowdryer.immutableUrl(
-                    "https://raw.githubusercontent.com/SonarSource/sonar-developer-toolset/master/eclipse/sonar-formatter.xml"
+                    "https://raw.githubusercontent.com/SonarSource/sonar-developer-toolset/" +
+                        "540ef32ba22c301f6d05a5305f4e1dbd204839f3/eclipse/sonar-formatter.xml"
                 )
             )
         licenseHeaderFile(rootProject.file("LICENSE_HEADER")).updateYearWithLatest(true)

--- a/iac-common/src/main/java/org/sonar/iac/common/api/tree/impl/SeparatedListImpl.java
+++ b/iac-common/src/main/java/org/sonar/iac/common/api/tree/impl/SeparatedListImpl.java
@@ -30,8 +30,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
-public record SeparatedListImpl<T extends Tree, U extends IacToken>(List<T> elements,
-                                                                    List<U> separators) implements SeparatedList<T, U> {
+public record SeparatedListImpl<T extends Tree, U extends IacToken> (List<T> elements,
+  List<U> separators) implements SeparatedList<T, U> {
 
   @Override
   public List<U> separators() {

--- a/iac-common/src/main/java/org/sonar/iac/common/yaml/tree/YamlTreeMetadata.java
+++ b/iac-common/src/main/java/org/sonar/iac/common/yaml/tree/YamlTreeMetadata.java
@@ -153,6 +153,7 @@ public record YamlTreeMetadata(String tag, TextRange textRange, int startPointer
       comments.addAll(comments(node.getEndComments()));
       return comments;
     }
+
     private static List<Comment> comments(@Nullable List<CommentLine> commentLines) {
       if (commentLines == null) {
         return Collections.emptyList();
@@ -169,4 +170,5 @@ public record YamlTreeMetadata(String tag, TextRange textRange, int startPointer
       var ranage = range(comment.getStartMark().orElse(null), comment.getEndMark().orElse(null));
       return new CommentImpl('#' + comment.getValue(), comment.getValue(), ranage);
     }
-  }}
+  }
+}


### PR DESCRIPTION
Update of sonar-formatter to version 23 so that records format are specified.

As discussed, `Blowdryer.immutableUrl` should point to an immutable file, as it will never be checked for updates.