### PR TITLE
Support entries with a single key in properties grammar

### DIFF
--- a/iac-extensions/spring-config/src/main/antlr/PropertiesLexer.g4
+++ b/iac-extensions/spring-config/src/main/antlr/PropertiesLexer.g4
@@ -27,15 +27,16 @@ public PropertiesLexer(CharStream input, boolean crLexerCostructor) {
 }
 }
 
-COMMENT         : [!#] -> pushMode(COMMENT_MODE);
-WHITESPACE         : [ \t\f\r\n\u2028\u2029]+ -> channel(HIDDEN);
-DELIMITER       : [ ]* [:=\t\f ] [ ]* -> pushMode(VALUE_MODE);
-CHARACTER       : ~ [!#:=\t\f ] -> pushMode(KEY_MODE);
+COMMENT         : [!#]                     -> pushMode(COMMENT_MODE);
+WHITESPACE      : [ \t\f\r\n\u2028\u2029]+ -> channel(HIDDEN);
+DELIMITER       : [ ]* [:=\t\f ] [ ]*      -> pushMode(VALUE_MODE);
+CHARACTER       : ~ [!#:=\t\f ]            -> pushMode(KEY_MODE);
 
 mode KEY_MODE;
 
-KEY_DELIMITER   : [ ]* [:=\t\f ] [ ]* -> type(DELIMITER), popMode, pushMode(VALUE_MODE);
-KEY_SLASH       : '\\' -> more, pushMode(INSIDE);
+KEY_DELIMITER   : [ ]* [:=\t\f ] [ ]*         -> type(DELIMITER), popMode, pushMode(VALUE_MODE);
+KEY_TERM        : [\r\n\u2028\u2029]+         -> type(WHITESPACE), popMode;
+KEY_SLASH       : '\\'                        -> more, pushMode(INSIDE);
 KEY_CHARACTER   : ~ [ :=\t\f\r\n\u2028\u2029] -> type(CHARACTER);
 
 mode COMMENT_MODE;
@@ -50,7 +51,7 @@ SLASH_JOINT     : '\r'? '\n' -> channel(HIDDEN), pushMode(IGNORE_LEADING_SPACES)
 
 mode IGNORE_LEADING_SPACES;
 
-NOT_SPACE    : ~[ ]  -> type(CHARACTER), popMode;
+NOT_SPACE    : ~[ ]   -> type(CHARACTER), popMode;
 IGNORE_SPACE : [ ]+   -> channel(HIDDEN), popMode;
 
 mode VALUE_MODE;

--- a/iac-extensions/spring-config/src/test/java/org/sonar/iac/springconfig/parser/properties/PropertiesParserBaseVisitorTest.java
+++ b/iac-extensions/spring-config/src/test/java/org/sonar/iac/springconfig/parser/properties/PropertiesParserBaseVisitorTest.java
@@ -1043,24 +1043,6 @@ class PropertiesParserBaseVisitorTest {
     assertThat(visitor.visited()).containsExactly("visitPropertiesFile <EOF>");
   }
 
-  private void parseProperties(String code) {
-    String stdErrOutput = "";
-    try (var outputStream = new ByteArrayOutputStream(); var printStream = new PrintStream(outputStream)) {
-      System.setErr(printStream);
-
-      var propertiesFileContext = createPropertiesFileContext(code);
-      stdErrOutput = outputStream.toString();
-
-      visitor.visitPropertiesFile(propertiesFileContext);
-      visitorTextRanges.visitPropertiesFile(propertiesFileContext);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-    if (!stdErrOutput.isBlank()) {
-      throw new RuntimeException("Found output in standard err:\n" + stdErrOutput);
-    }
-  }
-
   @Test
   void shouldParseFileStartingWithNewline() {
     var code = """
@@ -1111,6 +1093,24 @@ class PropertiesParserBaseVisitorTest {
       "visitKey multilinekey",
       "visitKey This is multiline key value",
       "visitEol <EOF>");
+  }
+
+  private void parseProperties(String code) {
+    String stdErrOutput = "";
+    try (var outputStream = new ByteArrayOutputStream(); var printStream = new PrintStream(outputStream)) {
+      System.setErr(printStream);
+
+      var propertiesFileContext = createPropertiesFileContext(code);
+      stdErrOutput = outputStream.toString();
+
+      visitor.visitPropertiesFile(propertiesFileContext);
+      visitorTextRanges.visitPropertiesFile(propertiesFileContext);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    if (!stdErrOutput.isEmpty()) {
+      throw new RuntimeException("Found output in standard err:\n" + stdErrOutput);
+    }
   }
 
   private static String printable(String input) {


### PR DESCRIPTION
This small improvement mitigates log entries to standard error by ANTLR4.
It was caused by a single key without the value after key value pair. In KEY_MODE the ANTRL4 was unable to recognize \n as a new line and print into standard err the following message: line 2:4 token recognition error at '\n'

This PR fixes grammar, reformats lexer rules and validates if standard error is empty