### PR TITLE
Change sca_scan condition to only run on main branch.

### DIFF
--- a/.cirrus/modules/build.star
+++ b/.cirrus/modules/build.star
@@ -126,7 +126,7 @@ def whitesource_script():
 def sca_scan_task():
     return {
         "sca_scan_task": {
-            "only_if": is_branch_qa_eligible(),
+            "only_if": is_main_branch(),
             "depends_on": "build",
             "env": whitesource_api_env(),
             "eks_container": custom_image_container_builder(),


### PR DESCRIPTION
Funnily, we can see in th `STARLARK.md` file in **Task definitions** chapter that the example code provided is the one about the definition of `sca_scan_task` and has the property `"only_if": is_main_branch()`.
Was it changed at some point for some reason?