### PR TITLE
SONARIAC-1511 Change the usage of ProgressReport to do proper reporting in cross file analysis

### DIFF
--- a/iac-common/src/main/java/org/sonar/iac/common/extension/analyzer/AbstractAnalyzer.java
+++ b/iac-common/src/main/java/org/sonar/iac/common/extension/analyzer/AbstractAnalyzer.java
@@ -39,6 +39,7 @@ import static org.sonar.iac.common.extension.ExceptionUtils.getStackTrace;
 
 public abstract class AbstractAnalyzer implements Analyzer {
 
+  protected static final long PROGRESS_REPORT_PERIOD_MILLIS = 10_000;
   private static final Logger LOG = LoggerFactory.getLogger(AbstractAnalyzer.class);
 
   private final String repositoryKey;

--- a/iac-common/src/main/java/org/sonar/iac/common/extension/analyzer/AbstractAnalyzer.java
+++ b/iac-common/src/main/java/org/sonar/iac/common/extension/analyzer/AbstractAnalyzer.java
@@ -34,12 +34,13 @@ import org.sonar.iac.common.extension.visitors.TreeVisitor;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.sonar.iac.common.extension.ExceptionUtils.getStackTrace;
 
 public abstract class AbstractAnalyzer implements Analyzer {
 
-  protected static final long PROGRESS_REPORT_PERIOD_MILLIS = 10_000;
+  protected static final long PROGRESS_REPORT_PERIOD_MILLIS = TimeUnit.SECONDS.toMillis(10);
   private static final Logger LOG = LoggerFactory.getLogger(AbstractAnalyzer.class);
 
   private final String repositoryKey;

--- a/iac-common/src/main/java/org/sonar/iac/common/extension/analyzer/Analyzer.java
+++ b/iac-common/src/main/java/org/sonar/iac/common/extension/analyzer/Analyzer.java
@@ -21,7 +21,6 @@ package org.sonar.iac.common.extension.analyzer;
 
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
-import org.sonarsource.analyzer.commons.ProgressReport;
 
 import java.util.Collection;
 

--- a/iac-common/src/main/java/org/sonar/iac/common/extension/analyzer/Analyzer.java
+++ b/iac-common/src/main/java/org/sonar/iac/common/extension/analyzer/Analyzer.java
@@ -26,5 +26,5 @@ import org.sonarsource.analyzer.commons.ProgressReport;
 import java.util.Collection;
 
 public interface Analyzer {
-  boolean analyseFiles(SensorContext sensorContext, Collection<InputFile> inputFiles, ProgressReport progressReport);
+  boolean analyseFiles(SensorContext sensorContext, Collection<InputFile> inputFiles, String languageName);
 }

--- a/iac-common/src/main/java/org/sonar/iac/common/extension/analyzer/CrossFileAnalyzer.java
+++ b/iac-common/src/main/java/org/sonar/iac/common/extension/analyzer/CrossFileAnalyzer.java
@@ -94,7 +94,8 @@ public class CrossFileAnalyzer extends AbstractAnalyzer {
     return applyVisitors(sensorContext, filesWithAst, List.of(checksVisitor), progressReportCheckVisitor);
   }
 
-  private boolean applyVisitors(SensorContext sensorContext, List<FileWithAst> filesWithAst, List<TreeVisitor<InputFileContext>> visitorsToBeApplied, ProgressReport progressReport) {
+  private boolean applyVisitors(SensorContext sensorContext, List<FileWithAst> filesWithAst, List<TreeVisitor<InputFileContext>> visitorsToBeApplied,
+    ProgressReport progressReport) {
     // Visit files
     for (FileWithAst fileWithAst : filesWithAst) {
       if (sensorContext.isCancelled()) {

--- a/iac-common/src/main/java/org/sonar/iac/common/extension/analyzer/SingleFileAnalyzer.java
+++ b/iac-common/src/main/java/org/sonar/iac/common/extension/analyzer/SingleFileAnalyzer.java
@@ -41,9 +41,14 @@ public class SingleFileAnalyzer extends AbstractAnalyzer {
     this.visitors = visitors;
   }
 
-  public boolean analyseFiles(SensorContext sensorContext, Collection<InputFile> inputFiles, ProgressReport progressReport) {
+  public boolean analyseFiles(SensorContext sensorContext, Collection<InputFile> inputFiles, String languageName) {
+    List<String> filenames = inputFiles.stream().map(InputFile::toString).toList();
+    var progressReport = new ProgressReport("Progress of the " + languageName + " analysis", PROGRESS_REPORT_PERIOD_MILLIS);
+    progressReport.start(filenames);
+
     for (InputFile inputFile : inputFiles) {
       if (sensorContext.isCancelled()) {
+        progressReport.cancel();
         return false;
       }
       var inputFileContext = createInputFileContext(sensorContext, inputFile);
@@ -54,6 +59,7 @@ public class SingleFileAnalyzer extends AbstractAnalyzer {
       }
       progressReport.nextFile();
     }
+    progressReport.stop();
     return true;
   }
 

--- a/iac-common/src/test/java/org/sonar/iac/common/extension/analyzer/AbstractAnalyzerTest.java
+++ b/iac-common/src/test/java/org/sonar/iac/common/extension/analyzer/AbstractAnalyzerTest.java
@@ -38,7 +38,6 @@ import org.sonar.iac.common.extension.TreeParser;
 import org.sonar.iac.common.extension.visitors.InputFileContext;
 import org.sonar.iac.common.extension.visitors.TreeVisitor;
 import org.sonar.iac.common.testing.IacTestUtils;
-import org.sonarsource.analyzer.commons.ProgressReport;
 
 import java.io.File;
 import java.io.IOException;

--- a/iac-common/src/test/java/org/sonar/iac/common/extension/analyzer/AbstractAnalyzerTest.java
+++ b/iac-common/src/test/java/org/sonar/iac/common/extension/analyzer/AbstractAnalyzerTest.java
@@ -62,7 +62,6 @@ abstract class AbstractAnalyzerTest {
   protected SensorContextTester context;
   protected TreeParser parser;
   protected DurationStatistics durationStatistics;
-  protected ProgressReport progressReport;
 
   protected InputFile emptyFile;
   protected InputFile fileWithContent;
@@ -75,7 +74,6 @@ abstract class AbstractAnalyzerTest {
   void init() throws IOException {
     parser = parser();
     durationStatistics = new DurationStatistics(mock(Configuration.class));
-    progressReport = mock(ProgressReport.class);
     baseDir = tmpDir.toPath().toRealPath().resolve("test-project").toFile();
     FileUtils.forceMkdir(baseDir);
     context = SensorContextTester.create(baseDir);
@@ -90,7 +88,7 @@ abstract class AbstractAnalyzerTest {
   void shouldParseEmptyFile() {
     Analyzer analyzer = analyzer(Collections.emptyList(), checksVisitor);
     List<InputFile> files = List.of(emptyFile);
-    assertThat(analyzer.analyseFiles(context, files, progressReport)).isTrue();
+    assertThat(analyzer.analyseFiles(context, files, "iac")).isTrue();
   }
 
   @Test
@@ -98,14 +96,14 @@ abstract class AbstractAnalyzerTest {
     Analyzer analyzer = analyzer(Collections.emptyList(), checksVisitor);
     List<InputFile> files = List.of(emptyFile);
     context.setCancelled(true);
-    assertThat(analyzer.analyseFiles(context, files, progressReport)).isFalse();
+    assertThat(analyzer.analyseFiles(context, files, "iac")).isFalse();
   }
 
   @Test
   void shouldReportParsingErrorOnInvalidFile() throws IOException {
     Analyzer analyzer = analyzer(Collections.emptyList(), checksVisitor);
     List<InputFile> files = List.of(IacTestUtils.invalidInputFile());
-    assertThat(analyzer.analyseFiles(context, files, progressReport)).isTrue();
+    assertThat(analyzer.analyseFiles(context, files, "iac")).isTrue();
     assertThat(logTester.logs(Level.ERROR)).containsExactly("Cannot read 'InvalidFile'");
 
     List<String> debugLogs = logTester.logs(Level.DEBUG);
@@ -119,7 +117,7 @@ abstract class AbstractAnalyzerTest {
     when(parser.parse(anyString(), any(InputFileContext.class))).thenThrow(new ParseException("Custom parse exception", null, null));
     Analyzer analyzer = analyzer(Collections.emptyList(), checksVisitor);
     List<InputFile> files = List.of(fileWithContent);
-    analyzer.analyseFiles(context, files, progressReport);
+    analyzer.analyseFiles(context, files, "iac");
 
     assertThat(logTester.logs(Level.ERROR)).containsExactly("Custom parse exception");
     List<String> debugLogs = logTester.logs(Level.DEBUG);
@@ -132,7 +130,7 @@ abstract class AbstractAnalyzerTest {
     when(parser.parse(anyString(), any(InputFileContext.class))).thenThrow(new RuntimeException("Custom runtime exception"));
     Analyzer analyzer = analyzer(Collections.emptyList(), checksVisitor);
     List<InputFile> files = List.of(fileWithContent);
-    analyzer.analyseFiles(context, files, progressReport);
+    analyzer.analyseFiles(context, files, "iac");
 
     assertThat(logTester.logs(Level.ERROR)).containsExactly("Cannot parse 'file.txt'");
     List<String> debugLogs = logTester.logs(Level.DEBUG);
@@ -148,7 +146,7 @@ abstract class AbstractAnalyzerTest {
       .when(visitorFail).scan(any(InputFileContext.class), any(Tree.class));
     Analyzer analyzer = analyzer(List.of(visitorFail), checksVisitor);
     List<InputFile> files = List.of(fileWithContent);
-    analyzer.analyseFiles(context, files, progressReport);
+    analyzer.analyseFiles(context, files, "iac");
 
     assertThat(logTester.logs(Level.ERROR)).containsExactly("Cannot analyse 'file.txt': Exception when scan mock");
   }
@@ -164,7 +162,7 @@ abstract class AbstractAnalyzerTest {
     settings.setProperty(IacSensor.FAIL_FAST_PROPERTY_NAME, true);
     context.setSettings(settings);
 
-    assertThatThrownBy(() -> analyzer.analyseFiles(context, files, progressReport))
+    assertThatThrownBy(() -> analyzer.analyseFiles(context, files, "iac"))
       .isInstanceOf(IllegalStateException.class)
       .hasMessage("Exception when analyzing 'file.txt'");
     assertThat(logTester.logs(Level.ERROR)).containsExactly("Cannot analyse 'file.txt': Exception when scan mock");
@@ -176,7 +174,7 @@ abstract class AbstractAnalyzerTest {
     Analyzer analyzer = analyzer(List.of(visitor), checksVisitor);
     List<InputFile> files = List.of(fileWithContent);
 
-    assertThat(analyzer.analyseFiles(context, files, progressReport)).isTrue();
+    assertThat(analyzer.analyseFiles(context, files, "iac")).isTrue();
   }
 
   TreeParser parser() {

--- a/iac-common/src/test/java/org/sonar/iac/common/extension/analyzer/CrossFileAnalyzerTest.java
+++ b/iac-common/src/test/java/org/sonar/iac/common/extension/analyzer/CrossFileAnalyzerTest.java
@@ -88,7 +88,7 @@ class CrossFileAnalyzerTest extends AbstractAnalyzerTest {
     CrossFileAnalyzer analyzer = new CrossFileAnalyzer("iac", parser, visitors, checksVisitor, durationStatistics);
 
     List<InputFile> files = List.of(fileWithContent, fileWithContent);
-    assertThat(analyzer.analyseFiles(context, files, progressReport)).isFalse();
+    assertThat(analyzer.analyseFiles(context, files, "iac")).isFalse();
   }
 
   @Test

--- a/iac-common/src/test/java/org/sonar/iac/common/extension/analyzer/CrossFileAnalyzerTest.java
+++ b/iac-common/src/test/java/org/sonar/iac/common/extension/analyzer/CrossFileAnalyzerTest.java
@@ -62,7 +62,7 @@ class CrossFileAnalyzerTest extends AbstractAnalyzerTest {
     CrossFileAnalyzer analyzer = new CrossFileAnalyzer("iac", parser, visitors, checksVisitor, durationStatistics);
 
     List<InputFile> files = List.of(file1, file2);
-    assertThat(analyzer.analyseFiles(context, files, progressReport)).isTrue();
+    assertThat(analyzer.analyseFiles(context, files, "iac")).isTrue();
 
     InOrder inOrder = Mockito.inOrder(parser, visitor1, visitor2, checksVisitor);
     inOrder.verify(parser).parse(eq("File 1 content"), any());
@@ -103,6 +103,6 @@ class CrossFileAnalyzerTest extends AbstractAnalyzerTest {
     CrossFileAnalyzer analyzer = new CrossFileAnalyzer("iac", parser, visitors, checksVisitor, durationStatistics);
 
     List<InputFile> files = List.of(fileWithContent);
-    assertThat(analyzer.analyseFiles(context, files, progressReport)).isFalse();
+    assertThat(analyzer.analyseFiles(context, files, "iac")).isFalse();
   }
 }

--- a/iac-common/src/test/java/org/sonar/iac/common/extension/analyzer/SingleFileAnalyzerTest.java
+++ b/iac-common/src/test/java/org/sonar/iac/common/extension/analyzer/SingleFileAnalyzerTest.java
@@ -64,7 +64,7 @@ class SingleFileAnalyzerTest extends AbstractAnalyzerTest {
     SingleFileAnalyzer analyzer = new SingleFileAnalyzer("iac", parser, visitors, durationStatistics);
 
     List<InputFile> files = List.of(file1, file2);
-    assertThat(analyzer.analyseFiles(context, files, progressReport)).isTrue();
+    assertThat(analyzer.analyseFiles(context, files, "iac")).isTrue();
 
     InOrder inOrder = Mockito.inOrder(parser, visitor1, visitor2, checksVisitor);
     inOrder.verify(parser).parse(eq("File 1 content"), any());


### PR DESCRIPTION
Proposed solution: move the ProgressReport responsibility to the analyzers, as we need different behavior between `SingleFileAnalyzer` and `CrossFileAnalyzer`.