### PR TITLE
chore: use the renamed sonar.sca.exclusions property

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ project(":iac-extensions:kubernetes") {
         properties {
             properties["sonar.sources"] as MutableCollection<String> +=
                 this@project.layout.projectDirectory.dir("src/common/java").asFile.toString()
-            property("sonar.sca.excludedManifests", "private/its/sources/**")
+            property("sonar.sca.exclusions", "private/its/sources/**")
         }
     }
 }


### PR DESCRIPTION
`sonar.sca.excludedManifests` is deprecated in SQS 2025.3 and is replaced with `sonar.sca.exlusions`. The behavior is exactly the same, this is just a rename to better match other sonar properties.